### PR TITLE
reset groupings whenever a project is selected

### DIFF
--- a/rubicon_ml/ui/model.py
+++ b/rubicon_ml/ui/model.py
@@ -192,6 +192,9 @@ class RubiconModel:
         """
         self._selected_project, *_ = [p for p in self._projects if p.name == selected_project_name]
 
+        # reset the experiment data when another project is selected 
+        self._experiment_table_dfs = {}
+
         grouped_experiment_dfs = self._maybe_run_async(
             self._selected_project.to_dask_df, group_by="commit_hash"
         )

--- a/rubicon_ml/ui/model.py
+++ b/rubicon_ml/ui/model.py
@@ -192,7 +192,7 @@ class RubiconModel:
         """
         self._selected_project, *_ = [p for p in self._projects if p.name == selected_project_name]
 
-        # reset the experiment data when another project is selected 
+        # reset the experiment data when another project is selected
         self._experiment_table_dfs = {}
 
         grouped_experiment_dfs = self._maybe_run_async(


### PR DESCRIPTION
## What

Fixes a bug within the dashboard when switching between projects with groupings. Now, the experiment data is reset whenever a new project is chosen.
