### PR TITLE
check for `root_dir` before creating

### DIFF
--- a/rubicon_ml/client/artifact.py
+++ b/rubicon_ml/client/artifact.py
@@ -1,3 +1,5 @@
+import os
+
 import fsspec
 
 from rubicon_ml.client import Base
@@ -54,12 +56,12 @@ class Artifact(Base):
             Defaults to the artifact's given name when logged.
         """
         if location is None:
-            location = "."
+            location = os.getcwd()
 
         if name is None:
             name = self._domain.name
 
-        with fsspec.open(f"{location.rstrip('/')}/{name}", "wb", auto_mkdir=False) as f:
+        with fsspec.open(os.path.join(location, name), "wb", auto_mkdir=False) as f:
             f.write(self.data)
 
     @property

--- a/rubicon_ml/repository/memory.py
+++ b/rubicon_ml/repository/memory.py
@@ -31,7 +31,8 @@ class MemoryRepository(LocalRepository):
         self.filesystem = fsspec.filesystem(self.PROTOCOL, **storage_options)
         self.root_dir = root_dir.rstrip("/") if root_dir is not None else "/root"
 
-        self.filesystem.mkdir(self.root_dir)
+        if not self.filesystem.exists(self.root_dir):
+            self.filesystem.mkdir(self.root_dir)
 
     def _persist_dataframe(self, df, path):
         """Persists the `dask` dataframe `df` to the in-memory

--- a/tests/unit/client/test_artifact_client.py
+++ b/tests/unit/client/test_artifact_client.py
@@ -38,7 +38,7 @@ def test_download_cwd(mock_open, project_client):
 
     artifact.download()
 
-    mock_open.assert_called_once_with(f"{os.getcwd()}/{artifact.name}", mode="wb")
+    mock_open.assert_called_once_with(os.path.join(os.getcwd(), artifact.name), mode="wb")
     mock_file().write.assert_called_once_with(data)
 
 


### PR DESCRIPTION
closes: #103 

---

## What
  * since `mkdir` throws a `FileExistsError` now, check to see if the file exists first
  * also noticed & fixed another failing test for the artifacts downloads
    * using `os.getcwd()` is probably a lot safer than `"."`

## How to Test
  * validate all the tests run with `fsspec` version `2021.5.0` and `2021.6.0`
