### PR TITLE
log fit params in pipeline

### DIFF
--- a/rubicon_ml/repository/utils/json.py
+++ b/rubicon_ml/repository/utils/json.py
@@ -12,9 +12,9 @@ class DomainJSONEncoder(json.JSONEncoder):
         within dataclasses, we need to leverage asdict()
         """
         if isinstance(obj, datetime):
-            return {"_type": "datetime", "value": str(obj)}
+            return {"_type": "datetime", "value": obj.strftime("%Y-%m-%d %H:%M:%S.%f")}
         if isinstance(obj, date):
-            return {"_type": "date", "value": str(obj)}
+            return {"_type": "date", "value": obj.isoformat()}
         if isinstance(obj, set):
             return {"_type": "set", "value": list(obj)}
         if isinstance(obj, TrainingMetadata):

--- a/rubicon_ml/sklearn/estimator_logger.py
+++ b/rubicon_ml/sklearn/estimator_logger.py
@@ -1,4 +1,4 @@
-import warnings
+from rubicon_ml.sklearn.utils import log_parameter_with_warning
 
 
 class EstimatorLogger:
@@ -20,20 +20,9 @@ class EstimatorLogger:
         self.experiment = experiment
         self.step_name = step_name
 
-    def _log_parameter_to_rubicon(self, name, value):
-        try:
-            self.experiment.log_parameter(name=f"{self.step_name}__{name}", value=value)
-        except Exception:
-            warning = (
-                f"step '{self.step_name}' failed to write parameter '{name}' with value {value} "
-                f"of type {type(value)}. try using the `FilterEstimatorLogger` with `ignore=['{name}']`"
-            )
-
-            warnings.warn(warning)
-
     def log_parameters(self):
         for name, value in self.estimator.get_params().items():
-            self._log_parameter_to_rubicon(name, value)
+            log_parameter_with_warning(self.experiment, f"{self.step_name}__{name}", value)
 
     def log_metric(self, name, value):
         self.experiment.log_metric(name, value=value)

--- a/rubicon_ml/sklearn/filter_estimator_logger.py
+++ b/rubicon_ml/sklearn/filter_estimator_logger.py
@@ -1,5 +1,6 @@
 from rubicon_ml.exceptions import RubiconException
 from rubicon_ml.sklearn.estimator_logger import EstimatorLogger
+from rubicon_ml.sklearn.utils import log_parameter_with_warning
 
 
 class FilterEstimatorLogger(EstimatorLogger):
@@ -49,4 +50,4 @@ class FilterEstimatorLogger(EstimatorLogger):
 
         for name, value in self.estimator.get_params().items():
             if (self.ignore and name not in self.ignore) or (self.select and name in self.select):
-                self._log_parameter_to_rubicon(name, value)
+                log_parameter_with_warning(self.experiment, f"{self.step_name}__{name}", value)

--- a/rubicon_ml/sklearn/pipeline.py
+++ b/rubicon_ml/sklearn/pipeline.py
@@ -1,6 +1,7 @@
 from sklearn.pipeline import Pipeline
 
 from rubicon_ml.sklearn.estimator_logger import EstimatorLogger
+from rubicon_ml.sklearn.utils import log_parameter_with_warning
 
 
 class RubiconPipeline(Pipeline):
@@ -62,7 +63,7 @@ class RubiconPipeline(Pipeline):
 
         super().__init__(steps, **kwargs)
 
-    def fit(self, X, y=None, tags=None, **fit_params):
+    def fit(self, X, y=None, tags=None, log_fit_params=True, **fit_params):
         """Fit the model and automatically log the `fit_params`
         to Rubicon. Optionally, pass `tags` to update the experiment's
         tags.
@@ -75,7 +76,10 @@ class RubiconPipeline(Pipeline):
             Training targets. Must fulfill label requirements for all steps of the pipeline.
         tags : list, optional
             Additional tags to add to the experiment during the fit.
-        fit_params : dict
+        log_fit_params : bool, optional
+            True to log the values passed as `fit_params` to this pipeline's experiment.
+            Defaults to True.
+        fit_params : dict, optional
             Additional keyword arguments to be passed to
             `sklearn.pipeline.Pipeline.fit()`.
         """
@@ -88,6 +92,10 @@ class RubiconPipeline(Pipeline):
         for step_name, estimator in self.steps:
             logger = self.get_estimator_logger(step_name, estimator)
             logger.log_parameters()
+
+        if log_fit_params:
+            for name, value in fit_params.items():
+                log_parameter_with_warning(self.experiment, name, value)
 
         return pipeline
 

--- a/rubicon_ml/sklearn/utils.py
+++ b/rubicon_ml/sklearn/utils.py
@@ -1,0 +1,14 @@
+import warnings
+
+
+def log_parameter_with_warning(experiment, name, value):
+    try:
+        experiment.log_parameter(name=name, value=value)
+    except Exception as e:
+        warning = (
+            f"{str(e)}: "
+            f"failed to write parameter '{name}' with value {value} of type {type(value)}. "
+            f"try using the `FilterEstimatorLogger` with `ignore=['{name}']`"
+        )
+
+        warnings.warn(warning)

--- a/tests/unit/repository/utils/test_json.py
+++ b/tests/unit/repository/utils/test_json.py
@@ -10,12 +10,14 @@ def test_can_serialize_datetime():
     serialized = json.dumps(to_serialize)
 
     assert "datetime" in serialized
-    assert str(now) in serialized
+    assert now.strftime("%Y-%m-%d %H:%M:%S.%f") in serialized
 
 
 def test_can_deserialize_datetime():
     now = datetime.utcnow()
-    to_deserialize = '{"date": {"_type": "datetime", "value": "' + str(now) + '"}}'
+    to_deserialize = (
+        '{"date": {"_type": "datetime", "value": "' + now.strftime("%Y-%m-%d %H:%M:%S.%f") + '"}}'
+    )
     deserialized = json.loads(to_deserialize)
 
     assert deserialized["date"] == now
@@ -27,12 +29,12 @@ def test_can_serialize_date():
     serialized = json.dumps(to_serialize)
 
     assert "date" in serialized
-    assert str(a_date) in serialized
+    assert a_date.isoformat() in serialized
 
 
 def test_can_deserialize_date():
     a_date = date(2021, 1, 1)
-    to_deserialize = '{"date": {"_type": "date", "value": "' + str(a_date) + '"}}'
+    to_deserialize = '{"date": {"_type": "date", "value": "' + a_date.isoformat() + '"}}'
     deserialized = json.loads(to_deserialize)
 
     assert deserialized["date"] == a_date
@@ -43,7 +45,7 @@ def test_can_serialize_set():
     to_serialize = {"tags": set(tags), "other": None}
     serialized = json.dumps(to_serialize)
 
-    assert "tags" in serialized
+    assert "set" in serialized
     assert "tag-a" in serialized
     assert "tag-b" in serialized
 

--- a/tests/unit/sklearn/test_pipeline.py
+++ b/tests/unit/sklearn/test_pipeline.py
@@ -45,6 +45,25 @@ def test_fit_logs_parameters(project_client, fake_estimator_cls):
     mock_log_parameters.assert_called_once()
 
 
+def test_fit_logs_fit_parameters(project_client, fake_estimator_cls):
+    project = project_client
+    estimator = fake_estimator_cls()
+    steps = [("est", estimator)]
+    user_defined_logger = {"est": FilterEstimatorLogger(ignore_all=True)}
+    pipeline = RubiconPipeline(project, steps, user_defined_logger)
+
+    with patch.object(Pipeline, "fit", return_value=None):
+        with patch.object(FilterEstimatorLogger, "log_parameters", return_value=None):
+            pipeline.fit(["fake data"], est__test_fit_param="test_value")
+
+    parameters = pipeline.experiment.parameters()
+    assert len(parameters) == 1
+
+    parameter = parameters[0]
+    assert parameter.name == "est__test_fit_param"
+    assert parameter.value == "test_value"
+
+
 def test_score_logs_metric(project_client, fake_estimator_cls):
     project = project_client
     estimator = fake_estimator_cls()


### PR DESCRIPTION
closes: #109 
---

## What
  * adds the ability to log parameters passed to the pipeline's `fit` method

## How to Test
  * `python -m pytest`
  * run the example in #109 and validate it no longer errors
