### PR TITLE
preserve the order in which artifacts were logged

### DIFF
--- a/rubicon_ml/repository/base.py
+++ b/rubicon_ml/repository/base.py
@@ -326,6 +326,7 @@ class BaseRepository:
                 domain.Artifact(**json.loads(metadata))
                 for metadata in self._cat_paths(artifact_metadata_paths)
             ]
+            artifacts.sort(key=lambda a: a.created_at)
         except FileNotFoundError:
             return []
 

--- a/tests/unit/repository/test_base_repo.py
+++ b/tests/unit/repository/test_base_repo.py
@@ -304,6 +304,9 @@ def test_get_artifacts(memory_repository):
         assert artifact.id in artifact_ids
         artifact_ids.remove(artifact.id)
 
+    assert artifacts[0].created_at < artifacts[1].created_at
+    assert artifacts[1].created_at < artifacts[2].created_at
+
 
 def test_get_artifacts_no_results(memory_repository):
     repository = memory_repository


### PR DESCRIPTION
closes: #113 

---

## What

When fetching the artifacts, preserve the order they were logged in
