### PR TITLE
Support creating the dashboard from a rubicon instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,20 +167,3 @@ Install and configure pre-commit to automatically run `black`, `flake8`, and
 Now `pre-commit` will run automatically on git commit and will ensure consistent
 code format throughout the project. You can format without committing via
 `pre-commit run` or skip these checks with `git commit --no-verify`.
-
-## Contributors
-
-<table>
-  <tr>
-    <td align="center"><a href="https://github.com/mmccarty"><img src="https://avatars.githubusercontent.com/u/625946?v=4"
-    width="100px;" alt=""/><br /><sub><b>Mike McCarty</b></sub></a><br /></td>
-    <td align="center"><a href="https://github.com/srilatharanganathan"><img src="https://avatars.githubusercontent.com/u/31327886?v=4"
-    width="100px;" alt=""/><br /><sub><b>Sri Ranganathan</b></sub></a><br /></td>
-    <td align="center"><a href="https://github.com/joe-wolfe21"><img src="https://avatars.githubusercontent.com/u/10947704?v=4"
-    width="100px;" alt=""/><br /><sub><b>Joe Wolfe</b></sub></a><br /></td>
-    <td align="center"><a href="https://github.com/RyanSoley"><img src="https://avatars.githubusercontent.com/u/53409969?v=4"
-    width="100px;" alt=""/><br /><sub><b>Ryan Soley</b></sub></a><br /></td>
-    <td align="center"><a href="https://github.com/dianelee217"><img src="https://avatars.githubusercontent.com/u/67274829?v=4"
-    width="100px;" alt=""/><br /><sub><b>Diane Lee</b></sub></a><br /></td>
-  </tr>
-</table>

--- a/docs/source/dashboard.rst
+++ b/docs/source/dashboard.rst
@@ -41,6 +41,8 @@ locate and load the in-memory projects and experiments.
 
   from rubicon_ml.ui import Dashboard
 
+  Dashboard(rubicon=rubicon) # if you already have a configured instance of Rubicon
+  # OR
   Dashboard(persistence="memory", root_dir="/rubicon-root").run_server()
 
 The above launches the dashboard on ``localhost:8050`` and will run from any

--- a/notebooks/quick-look.ipynb
+++ b/notebooks/quick-look.ipynb
@@ -235,7 +235,7 @@
     "from rubicon_ml.ui import Dashboard\n",
     "\n",
     "\n",
-    "Dashboard(persistence=\"filesystem\", root_dir=root_path).run_server_inline()"
+    "Dashboard(rubicon=rubicon).run_server_inline()"
    ]
   },
   {

--- a/rubicon_ml/cli.py
+++ b/rubicon_ml/cli.py
@@ -47,7 +47,9 @@ def ui(root_dir, host, port, debug, page_size, storage_options):
     storage_options_dict = {
         storage_options[i][2:]: storage_options[i + 1] for i in range(0, len(storage_options), 2)
     }
-    dashboard = Dashboard("filesystem", root_dir, page_size=page_size, **storage_options_dict)
+    dashboard = Dashboard(
+        persistence="filesystem", root_dir=root_dir, page_size=page_size, **storage_options_dict
+    )
 
     server_kwargs = dict(debug=debug, port=port, host=host)
     server_kwargs = {k: v for k, v in server_kwargs.items() if v is not None}

--- a/rubicon_ml/ui/dashboard.py
+++ b/rubicon_ml/ui/dashboard.py
@@ -5,6 +5,8 @@ import dash_bootstrap_components as dbc
 import dash_html_components as html
 from dash import Dash
 
+from rubicon_ml import Rubicon
+from rubicon_ml.exceptions import RubiconException
 from rubicon_ml.ui.callbacks import (
     set_project_explorer_callbacks,
     set_project_selection_callbacks,
@@ -19,11 +21,20 @@ from rubicon_ml.ui.views import (
 
 
 class Dashboard:
-    """The dashboard for exploring logged data.
+    """A dashboard for exploring logged data. The dashboard
+    relies on existing rubicon_ml data, which can be passed
+    in the following ways:
+        * by passing in an existing Rubicon object, which can be the
+          the synchronous or asynchronous version (see param details below).
+        * by passing in ``persistence`` and ``root_dir``, which will configure
+          a rubicon object for you (useful from CLI or independent dashboard configuration).
 
     Parameters
     ----------
-    persistence : str
+    rubicon : rubicon_ml.Rubicon or rubicon_ml.client.asynchronous.Rubicon, optional
+        A top level Rubicon instance which holds the configuration for
+        the data you wish to visualize.
+    persistence : str, optional
         The persistence type. Can be one of ["filesystem", "memory"].
     root_dir : str, optional
         Absolute or relative filepath of the root directory holding Rubicon data.
@@ -39,18 +50,29 @@ class Dashboard:
         troubles.
     storage_options : dict, optional
         Additional keyword arguments specific to the protocol being chosen. They
-        are passed directly to the underlying filesystem class.
+        are passed directly to the underlying filesystem class when ``persistence``
+        and ``root_dir`` are used.
     """
 
     def __init__(
         self,
-        persistence,
+        rubicon=None,
+        persistence=None,
         root_dir=None,
         page_size=10,
         dash_options={},
         **storage_options,
     ):
-        self.rubicon_model = RubiconModel(persistence, root_dir, **storage_options)
+
+        if not rubicon and not all([persistence, root_dir]):
+            raise RubiconException(
+                "Either `rubicon` or both `persistence` and `root_dir` must be provided."
+            )
+
+        if not rubicon:
+            rubicon = Rubicon(persistence, root_dir, **storage_options)
+
+        self.rubicon_model = RubiconModel(rubicon)
 
         self._app = Dash(__name__, title="Rubicon", **dash_options)
         self._app._rubicon_model = self.rubicon_model

--- a/rubicon_ml/ui/model.py
+++ b/rubicon_ml/ui/model.py
@@ -3,7 +3,6 @@ import asyncio
 import numpy as np
 import pandas as pd
 
-from rubicon_ml import Rubicon
 from rubicon_ml.client.asynchronous import Rubicon as AsynRubicon
 
 
@@ -12,20 +11,13 @@ class RubiconModel:
 
     Parameters
     ----------
-    persistence : str
-        The persistence type. Can be one of ["filesystem", "memory"].
-    root_dir : str, optional
-        Absolute or relative filepath of the root directory holding Rubicon data.
-        Use absolute path for best performance. Defaults to the local filesystem.
-        Prefix with s3:// to use s3 instead.
-    storage_options : dict, optional
-        Additional keyword arguments specific to the protocol being chosen. They
-        are passed directly to the underlying filesystem class.
+    rubicon : rubicon_ml.Rubicon or rubicon_ml.client.asynchronous.Rubicon, optional
+        A top level Rubicon instance which holds the configuration for
+        the data you wish to visualize.
     """
 
-    def __init__(self, persistence, root_dir, **storage_options):
-        self._rubicon_cls = AsynRubicon if root_dir and root_dir.startswith("s3") else Rubicon
-        self._rubicon = self._rubicon_cls(persistence, root_dir, **storage_options)
+    def __init__(self, rubicon):
+        self._rubicon = rubicon
 
         self._projects = []
         self._selected_project = None
@@ -37,7 +29,7 @@ class RubiconModel:
         """Runs `rubicon_func` asynchronously if logging to S3,
         synchronously otherwise.
         """
-        if self._rubicon_cls == AsynRubicon:
+        if isinstance(self._rubicon, AsynRubicon):
             return asyncio.run_coroutine_threadsafe(
                 rubicon_func(*args, **kwargs), loop=self._rubicon.repository.filesystem.loop
             ).result()


### PR DESCRIPTION
## What

Currently the dashboard relies on persistence and root-dir information and creates a rubicon instance internally. However, it's common that users who want to display the dashboard already have a properly configured rubicon instance, so it was redundant. This allows just passing the rubicon instance for that case. 
