### PR TITLE
use `fsspec` to create path for local dataframes

### DIFF
--- a/rubicon_ml/repository/base.py
+++ b/rubicon_ml/repository/base.py
@@ -1,6 +1,5 @@
 import os
 import warnings
-from pathlib import Path
 
 import fsspec
 import pandas as pd
@@ -424,7 +423,7 @@ class BaseRepository:
         would leverage dask for large dataframes.
         """
         if isinstance(df, pd.DataFrame):
-            Path(path).mkdir(parents=True, exist_ok=True)
+            self.filesystem.mkdir(path, parents=True, exist_ok=True)
             path = f"{path}/data.parquet"
 
         df.to_parquet(path, engine="pyarrow")


### PR DESCRIPTION
## What
  * the `pathlib` `mkdir` call just wasn't making any dirs
  * uses `fsspec`'s `mkdir` instead of `pathlib`

## How to Test
  * log a dataframe to the local filesystem and validate that it works
  * I tested this against S3 to validate that it did not break S3 dataframe logging
