### PR TITLE
pre-release

### DIFF
--- a/rubicon_ml/client/project.py
+++ b/rubicon_ml/client/project.py
@@ -250,13 +250,15 @@ class Project(Base, ArtifactMixin, DataframeMixin):
 
         if name is not None:
             experiments = [e for e in self.experiments() if e.name == name]
+
             if len(experiments) == 0:
-                raise RubiconException(f"No experiment found with name {name}.")
+                raise RubiconException(f"No experiment found with name '{name}'.")
             elif len(experiments) > 1:
                 warnings.warn(
-                    f"Multiple experiments found with name {name}."
+                    f"Multiple experiments found with name '{name}'."
                     " Returning most recently logged."
                 )
+
             experiment = experiments[-1]
         else:
             experiment = Experiment(self.repository.get_experiment(self.name, id), self)

--- a/rubicon_ml/client/project.py
+++ b/rubicon_ml/client/project.py
@@ -268,6 +268,7 @@ class Project(Base, ArtifactMixin, DataframeMixin):
         query type `qtype` and by `name`.
         """
         filtered_experiments = experiments
+
         if len(tags) > 0:
             filtered_experiments = []
             [
@@ -277,6 +278,7 @@ class Project(Base, ArtifactMixin, DataframeMixin):
             ]
         if name is not None:
             filtered_experiments = [e for e in filtered_experiments if e.name == name]
+
         self._experiments = filtered_experiments
 
     def experiments(self, tags=[], qtype="or", name=None):

--- a/rubicon_ml/repository/base.py
+++ b/rubicon_ml/repository/base.py
@@ -120,7 +120,7 @@ class BaseRepository:
                 domain.Project(**json.loads(metadata))
                 for metadata in self._cat_paths(project_metadata_paths)
             ]
-            projects.sort(key=lambda a: a.created_at)
+            projects.sort(key=lambda p: p.created_at)
         except FileNotFoundError:
             return []
 
@@ -208,7 +208,7 @@ class BaseRepository:
                 domain.Experiment(**json.loads(metadata))
                 for metadata in self._cat_paths(experiment_metadata_paths)
             ]
-            experiments.sort(key=lambda a: a.created_at)
+            experiments.sort(key=lambda e: e.created_at)
         except FileNotFoundError:
             return []
 
@@ -530,7 +530,7 @@ class BaseRepository:
                 domain.Dataframe(**json.loads(metadata))
                 for metadata in self._cat_paths(dataframe_metadata_paths)
             ]
-            dataframes.sort(key=lambda a: a.created_at)
+            dataframes.sort(key=lambda d: d.created_at)
         except FileNotFoundError:
             return []
 
@@ -694,7 +694,7 @@ class BaseRepository:
                 domain.Feature(**json.loads(metadata))
                 for metadata in self._cat_paths(feature_metadata_paths)
             ]
-            features.sort(key=lambda a: a.created_at)
+            features.sort(key=lambda f: f.created_at)
         except FileNotFoundError:
             return []
 
@@ -800,7 +800,7 @@ class BaseRepository:
                 domain.Metric(**json.loads(metadata))
                 for metadata in self._cat_paths(metric_metadata_paths)
             ]
-            metrics.sort(key=lambda a: a.created_at)
+            metrics.sort(key=lambda m: m.created_at)
         except FileNotFoundError:
             return []
 
@@ -905,7 +905,7 @@ class BaseRepository:
                 domain.Parameter(**json.loads(metadata))
                 for metadata in self._cat_paths(parameter_metadata_paths)
             ]
-            parameters.sort(key=lambda a: a.created_at)
+            parameters.sort(key=lambda p: p.created_at)
         except FileNotFoundError:
             return []
 

--- a/tests/unit/client/test_mixin_client.py
+++ b/tests/unit/client/test_mixin_client.py
@@ -154,6 +154,21 @@ def test_artifacts_by_name(project_client):
     assert artifact_b.id in [a.id for a in artifacts]
 
 
+def test_artifact_warning(project_client, test_dataframe):
+    project = project_client
+    data = b"content"
+    artifact_a = ArtifactMixin.log_artifact(project, data_bytes=data, name="test.txt")
+    artifact_b = ArtifactMixin.log_artifact(project, data_bytes=data, name="test.txt")
+
+    with warnings.catch_warnings(record=True) as w:
+        artifact_c = ArtifactMixin.artifact(project, name="test.txt")
+        assert (
+            "Multiple artifacts found with name 'test.txt'. Returning most recently logged"
+        ) in str(w[0].message)
+    assert artifact_c.id != artifact_a.id
+    assert artifact_c.id == artifact_b.id
+
+
 def test_artifact_name_not_found_error(project_client):
     project = project_client
     with pytest.raises(RubiconException) as e:

--- a/tests/unit/client/test_mixin_client.py
+++ b/tests/unit/client/test_mixin_client.py
@@ -154,12 +154,19 @@ def test_artifacts_by_name(project_client):
     assert artifact_b.id in [a.id for a in artifacts]
 
 
-def test_artifacts_name_not_found_error(project_client):
+def test_artifact_name_not_found_error(project_client):
     project = project_client
     with pytest.raises(RubiconException) as e:
-        ArtifactMixin.artifacts(project, name="test.txt")
+        ArtifactMixin.artifact(project, name="test.txt")
 
-    assert "No artifacts found with name test.txt." in str(e)
+    assert "No artifact found with name 'test.txt'." in str(e)
+
+
+def test_artifacts_name_not_found_error(project_client):
+    project = project_client
+    artifacts = ArtifactMixin.artifacts(project, name="test.txt")
+
+    assert artifacts == []
 
 
 def test_artifact_by_name(project_client):
@@ -259,7 +266,7 @@ def test_dataframe_warning(project_client, test_dataframe):
     with warnings.catch_warnings(record=True) as w:
         dataframe_c = DataframeMixin.dataframe(project, name=test_df_name)
         assert (
-            "Multiple dataframes found with name test_df. Returning most recently logged"
+            "Multiple dataframes found with name 'test_df'. Returning most recently logged"
         ) in str(w[0].message)
     assert dataframe_c.id != dataframe_a.id
     assert dataframe_c.id == dataframe_b.id
@@ -270,15 +277,14 @@ def test_dataframe_by_name_not_found(project_client, test_dataframe):
     test_df_name = "test_df"
     with pytest.raises(RubiconException) as e:
         DataframeMixin.dataframe(project, name=test_df_name)
-    assert "No dataframe found with name test_df." in str(e.value)
+    assert "No dataframe found with name 'test_df'." in str(e.value)
 
 
 def test_dataframes_by_name_not_found(project_client, test_dataframe):
     project = project_client
     test_df_name = "test_df"
-    with pytest.raises(RubiconException) as e:
-        DataframeMixin.dataframes(project, name=test_df_name)
-    assert "No dataframe found with name test_df." in str(e.value)
+    dataframes = DataframeMixin.dataframes(project, name=test_df_name)
+    assert dataframes == []
 
 
 def test_dataframes_tagged_and(project_client, test_dataframe):

--- a/tests/unit/client/test_project_client.py
+++ b/tests/unit/client/test_project_client.py
@@ -1,3 +1,4 @@
+import warnings
 from unittest import mock
 
 import pytest
@@ -109,12 +110,26 @@ def test_experiment_by_name(project_client):
     assert experiment.name == "exp1"
 
 
+def test_experiment_warning(project_client, test_dataframe):
+    project = project_client
+    experiment_a = project.log_experiment(name="exp1")
+    experiment_b = project.log_experiment(name="exp1")
+
+    with warnings.catch_warnings(record=True) as w:
+        experiment_c = project.experiment(name="exp1")
+        assert (
+            "Multiple experiments found with name 'exp1'. Returning most recently logged"
+        ) in str(w[0].message)
+    assert experiment_c.id != experiment_a.id
+    assert experiment_c.id == experiment_b.id
+
+
 def test_experiment_name_not_found_error(project_client):
     project = project_client
     with pytest.raises(RubiconException) as e:
         project.experiment(name="exp1")
 
-    assert "No experiment found with name exp1." in str(e)
+    assert "No experiment found with name 'exp1'." in str(e)
 
 
 def test_experiments_tagged_and(project_client):


### PR DESCRIPTION
## What
  * mostly small variable name & formatting cleanup
  * moved the "name not found" errors into the single item getters
    * the convention with tags and multi item getters is to just return nothing when there is no match, so we'll do the same with names
  * moved dataframe name filtering into `_filter_dataframes` to match `_filter_experiments`
  * added a couple more tests

## How to Test
  * `python -m pytest`
