### PR TITLE
add metric plot to `viz`

### DIFF
--- a/notebooks/viz/plot-metric-correlation.ipynb
+++ b/notebooks/viz/plot-metric-correlation.ipynb
@@ -1,0 +1,72 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0b35758-483e-463a-b955-13a3f8ab5129",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "\n",
+    "from rubicon_ml import Rubicon\n",
+    "from rubicon_ml.viz import plot_metric_correlation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a4bcd49-999f-48ff-9dea-955f1ea1881d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rubicon = Rubicon(persistence=\"memory\", auto_git_enabled=True)\n",
+    "project = rubicon.get_or_create_project(\"metric correlation plot\")\n",
+    "\n",
+    "for i in range(0, 100):\n",
+    "    experiment = project.log_experiment()\n",
+    "\n",
+    "    experiment.log_parameter(name=\"is_standardized\", value=random.choice([True, False]))\n",
+    "    experiment.log_parameter(name=\"n_estimators\", value=random.randrange(2, 10, 2))\n",
+    "    experiment.log_parameter(name=\"sample\", value=random.choice([\"A\", \"B\", \"C\", \"D\", \"E\"]))\n",
+    "\n",
+    "    experiment.log_metric(name=\"accuracy\", value=random.random())\n",
+    "    experiment.log_metric(name=\"confidence\", value=random.random())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c1bbd4e-7783-467b-8831-3a3dbfa932c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_metric_correlation(\n",
+    "    project.experiments(),\n",
+    "    selected_metric=\"accuracy\",\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/rubicon_ml/viz/__init__.py
+++ b/rubicon_ml/viz/__init__.py
@@ -1,6 +1,13 @@
 from rubicon_ml.viz.artifact_plot import plot_artifacts
 from rubicon_ml.viz.dataframe_plot import plot_dataframes
 from rubicon_ml.viz.experiments_table import view_experiments_table
+from rubicon_ml.viz.metric_correlation_plot import plot_metric_correlation
 from rubicon_ml.viz.metric_lists_comparison import compare_metric_lists
 
-__all__ = ["compare_metric_lists", "plot_artifacts", "plot_dataframes", "view_experiments_table"]
+__all__ = [
+    "compare_metric_lists",
+    "plot_artifacts",
+    "plot_dataframes",
+    "plot_metric_correlation",
+    "view_experiments_table",
+]

--- a/rubicon_ml/viz/assets/css/metric-correlation-plot.css
+++ b/rubicon_ml/viz/assets/css/metric-correlation-plot.css
@@ -1,3 +1,7 @@
+#metric-correlation-header-row {
+    width: 75%;
+}
+
 #metric-correlation-plot-container {
     margin: -3rem 0rem -1.5rem -1.5rem;
 }

--- a/rubicon_ml/viz/assets/css/metric-correlation-plot.css
+++ b/rubicon_ml/viz/assets/css/metric-correlation-plot.css
@@ -1,0 +1,3 @@
+#metric-correlation-plot-container {
+    margin: -3rem 0rem -1.5rem -1.5rem;
+}

--- a/rubicon_ml/viz/colors.py
+++ b/rubicon_ml/viz/colors.py
@@ -1,3 +1,14 @@
+import plotly.express as px
+
 dark_blue = "rgb(40, 60, 70)"
 light_blue = "rgb(200, 230, 250)"
 plot_background_blue = "rgb(240, 250, 255)"
+transparent = "rgba(255, 255, 255, 0)"
+
+
+def get_rubicon_colorscale(num_colors, low=0.33):
+    return px.colors.sample_colorscale(
+        "Blues",
+        num_colors,
+        low=low,
+    )

--- a/rubicon_ml/viz/dataframe_plot.py
+++ b/rubicon_ml/viz/dataframe_plot.py
@@ -2,7 +2,11 @@ import plotly.express as px
 from dash import dcc, html
 
 from rubicon_ml.viz.base import VizBase
-from rubicon_ml.viz.colors import light_blue, plot_background_blue
+from rubicon_ml.viz.colors import (
+    get_rubicon_colorscale,
+    light_blue,
+    plot_background_blue,
+)
 from rubicon_ml.viz.common import dropdown_header
 
 
@@ -49,8 +53,8 @@ class DataframePlot(VizBase):
         if "color" not in self.plotting_func_kwargs:
             self.plotting_func_kwargs["color"] = "experiment_id"
         if "color_discrete_sequence" not in self.plotting_func_kwargs:
-            self.plotting_func_kwargs["color_discrete_sequence"] = px.colors.sample_colorscale(
-                "Blues", len(self.experiments), low=0.33
+            self.plotting_func_kwargs["color_discrete_sequence"] = get_rubicon_colorscale(
+                len(self.experiments),
             )
 
         figure = self.plotting_func(

--- a/rubicon_ml/viz/metric_correlation_plot.py
+++ b/rubicon_ml/viz/metric_correlation_plot.py
@@ -1,0 +1,192 @@
+import json
+
+import numpy as np
+import plotly.graph_objects as go
+from dash import callback_context, dcc, html
+from dash.dependencies import ALL, Input, Output, State
+
+from rubicon_ml.viz.base import VizBase
+from rubicon_ml.viz.colors import get_rubicon_colorscale, light_blue, transparent
+from rubicon_ml.viz.common import dropdown_header
+
+
+class MetricCorrelationPlot(VizBase):
+    def __init__(
+        self,
+        experiments,
+        selected_metric,
+        metric_names=None,
+        parameter_names=None,
+        dash_kwargs={},
+    ):
+        super().__init__(dash_kwargs=dash_kwargs, dash_title="rubicon-ml: plot metric correlation")
+
+        self.experiments = experiments
+        self.selected_metric = selected_metric
+
+        self.experiment_records = {}
+        self.metric_names = set()
+        self.parameter_names = set()
+
+        for experiment in self.experiments:
+            experiment_record = {"metrics": {}, "parameters": {}}
+
+            for metric in experiment.metrics():
+                if metric_names is None or metric.name in metric_names:
+                    experiment_record["metrics"][metric.name] = metric.value
+
+                    self.metric_names.add(metric.name)
+
+            for parameter in experiment.parameters():
+                if parameter_names is None or parameter.name in parameter_names:
+                    experiment_record["parameters"][parameter.name] = parameter.value
+
+                    self.parameter_names.add(parameter.name)
+
+            self.experiment_records[experiment.id] = experiment_record
+
+        if self.selected_metric not in self.metric_names:
+            raise ValueError(
+                f"no metric named `selected_metric` '{self.selected_metric}'"
+                " logged to any experiment in `experiments`."
+            )
+
+        self.parameter_names = list(self.parameter_names)
+        self.metric_names = list(self.metric_names)
+        self.metric_names.sort()
+
+        self.app.layout = self._build_frame(self._build_layout())
+
+        _register_callbacks(self.app)
+
+    def _build_layout(self):
+        return html.Div(
+            [
+                self._to_store(ignore_attributes=["app", "experiments"]),
+                dropdown_header(
+                    self.metric_names,
+                    self.selected_metric,
+                    "comparing metric ",
+                    f" over {len(self.experiments)} experiments",
+                    "metric-correlation",
+                ),
+                dcc.Loading(
+                    html.Div(
+                        dcc.Graph(
+                            id="metric-correlation-plot",
+                        ),
+                        id="metric-correlation-plot-container",
+                    ),
+                    color=light_blue,
+                ),
+            ],
+            id="metric-correlation-plot-layout-container",
+        )
+
+
+def _register_callbacks(app):
+    def _get_dimension(label, values):
+        if isinstance(values[0], str):
+            unique_values, values = np.unique(values, return_inverse=True)
+
+            dimension = {
+                "label": label,
+                "ticktext": unique_values,
+                "tickvals": list(range(0, len(unique_values))),
+                "values": values,
+            }
+        elif isinstance(values[0], bool):
+            values = [int(value) for value in values]
+
+            dimension = {
+                "label": label,
+                "ticktext": ["False", "True"],
+                "tickvals": [0, 1],
+                "values": values,
+            }
+        else:
+            dimension = {
+                "label": label,
+                "values": values,
+            }
+
+        return dimension
+
+    @app.callback(
+        [
+            Output("metric-correlation-plot", "figure"),
+            Output("metric-correlation-dropdown", "label"),
+        ],
+        Input({"type": "metric-correlation-dropdown-button", "index": ALL}, "n_clicks"),
+        State("memory-store", "data"),
+    )
+    def update_selected_metric(n_clicks, data):
+        property_id = callback_context.triggered[0].get("prop_id")
+        property_value = property_id[: property_id.index(".")]
+
+        if not property_value:
+            selected_metric = data["selected_metric"]
+        else:
+            selected_metric = json.loads(property_value).get("index")
+
+            data["selected_metric"] = selected_metric
+
+        experiment_records = data["experiment_records"]
+        parameter_names = data["parameter_names"]
+        selected_metric = data["selected_metric"]
+
+        parameter_values = {}
+
+        for parameter_name in parameter_names:
+            parameter_values[parameter_name] = [
+                record["parameters"][parameter_name] for record in experiment_records.values()
+            ]
+
+        metric_values = [
+            record["metrics"][selected_metric] for record in experiment_records.values()
+        ]
+
+        plot_dimensions = []
+
+        for parameter_name, parameter_values in parameter_values.items():
+            plot_dimensions.append(_get_dimension(parameter_name, parameter_values))
+
+        plot_dimensions.append(_get_dimension(selected_metric, metric_values))
+
+        metric_correlation_plot = go.Figure(
+            go.Parcoords(
+                line={
+                    "color": metric_values,
+                    "colorscale": get_rubicon_colorscale(len(experiment_records)),
+                    "showscale": True,
+                },
+                dimensions=plot_dimensions,
+            ),
+        )
+        metric_correlation_plot.update_layout(paper_bgcolor=transparent)
+
+        return metric_correlation_plot, selected_metric
+
+
+def plot_metric_correlation(
+    experiments,
+    selected_metric,
+    metric_names=None,
+    parameter_names=None,
+    dash_kwargs={},
+    i_frame_kwargs={},
+    run_server_kwargs={},
+):
+    if "height" not in i_frame_kwargs:
+        i_frame_kwargs["height"] = "550px"
+
+    return MetricCorrelationPlot(
+        experiments,
+        selected_metric,
+        metric_names=metric_names,
+        parameter_names=parameter_names,
+        dash_kwargs=dash_kwargs,
+    ).run_server_inline(
+        i_frame_kwargs=i_frame_kwargs,
+        **run_server_kwargs,
+    )


### PR DESCRIPTION
closes: #147  

---

## What
  * ports over the metric correlation plot from the existing `ui` submodule
  * adds an example notebook for running the new plot

## How to Test
  * if you haven't since the dash updates, create a new dev environment
    * `mamba env create -f environment.yml`
  * run through the example notebook and ensure the new experiment plot works the same as the old one
    * this plot should replacate the bottom half of the [dashboard](https://capitalone.github.io/rubicon-ml/dashboard.html#features) experience
    * https://github.com/capitalone/rubicon-ml/blob/147-metric-plot/notebooks/viz/plot-metric-correlation.ipynb
