### PR TITLE
test package before PyPi release

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -22,8 +22,8 @@ jobs:
     - name: Set up Python
       uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.9
-        mamba-version: "*"
+        python-version: '3.9'
+        mamba-version: '*'
         channels: conda-forge
         channel-priority: true
         activate-environment: rubicon-ml-docs

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,7 +1,7 @@
 # This workflow publishes the package to pypi.
 # For more details:
 # https://docs.github.com/en/actions/guides/building-and-testing-python#publishing-to-package-registries
-name: Publish
+name: Publish to PyPi
 
 on:
   release:
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      # fetch all tags so `versioneer` can properly determine current version
       with:
-        # fetch all tags so `versioneer` can properly determine current version
         fetch-depth: 0
     - name: Check if current commit is tagged
       # fails and cancels release if the current commit is not tagged
@@ -28,11 +28,17 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
-    - name: Build and publish
+    - name: Build
+      run: |
+        python setup.py sdist bdist_wheel
+    - name: Test build
+      # fails and cancels release if the built package fails to import
+      run: |
+        python -c 'import rubicon_ml; print(rubicon_ml.__version__)'
+    - name: Publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         TWINE_REPOSITORY: pypi
       run: |
-        python setup.py sdist bdist_wheel
         twine upload dist/*


### PR DESCRIPTION
## What
  * the last PyPi release built a bad artifact that wasn't caught until a similar test in the conda release
    * adds a test to this release to validate `rubicon_ml` imports without error

## How to Test
  * try a release once its merged
