### PR TITLE
better test config & dev docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,27 +135,25 @@ tests/integration`. Or by simply running `pytest` to execute all of them.
 **Note**: some integration tests are intentionally `marked` to control when they
 are run (i.e. not during CICD). These tests include:
 
-* Integration tests that connect to physical filesystems (local, S3). You'll
-  want to configure the `root_dir` appropriately for these tests
-  (tests/integration/test_async_rubicon.py, tests/integration/test_rubicon.py).
-  And they can be run with:
+* Integration tests that write to physical filesystems - local and S3. Local
+  files will be written to `./test-rubicon` relative to where the tests are run.
+  An S3 path must also be provided to run these tests. By default, these
+  tests are disabled. To enable them, run:
 
     ```
-    pytest -m "physical_filesystem_test"
+    pytest -m "write_files" --s3-path "s3://my-bucket/my-key"
     ```
 
-* Integration tests for the dashboard. To run these integration tests locally,
-  you'll need to install one of the WebDrivers. To do so, follow the `Install`
-  instructions in the [Dash Testing Docs](https://dash.plotly.com/testing) or
-  install via brew with `brew cask install chromedriver`. You may have to update
-  your permissions in Security & Privacy to install with brew.
+* Integration tests that run Jupyter notebooks. These tests are a bit slower
+  than the rest of the tests in the suite as they need to launch Jupyter servers.
+  By default, they are enabled. To disable them, run:
 
     ```
-    pytest -m "dashboard_test"
+    pytest -m "not run_notebooks and not write_files"
     ```
 
-    **Note**: The `--headless` flag can be added to run the dashboard tests in
-    headless mode.
+    **Note**: When simply running `pytest`, `-m "not write_files"` is the
+    default. So, we need to also apply it when disabling notebook tests.
 
 ## Code Formatting
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,9 +32,8 @@ combine_as_imports = True
 
 [tool:pytest]
 markers = 
-    dashboard_test: marks tests for the dashboard that require a web driver
-    notebook_test: marks tests for the notebooks
-    physical_filesystem_test: marks tests that write to physical filesystems
-addopts = --cov=./rubicon_ml --cov-report=term-missing --cov-fail-under=90 -m="not dashboard_test and not physical_filesystem_test"
+    run_notebooks: tests that run Jupyter notebooks
+    write_files: tests that physically write files to local and S3 filesystems
+addopts = --cov=./rubicon_ml --cov-report=term-missing --cov-fail-under=90 -m="not write_files"
 minversion = 3.2
 xfail_strict = True

--- a/tests/integration/test_async_rubicon.py
+++ b/tests/integration/test_async_rubicon.py
@@ -9,7 +9,7 @@ from rubicon_ml.client.asynchronous import Rubicon
 filesystems = [
     pytest.param(
         Rubicon(persistence="filesystem", root_dir="s3://change-me"),
-        marks=pytest.mark.physical_filesystem_test,
+        marks=pytest.mark.write_files,
     ),
 ]
 

--- a/tests/integration/test_rubicon.py
+++ b/tests/integration/test_rubicon.py
@@ -9,11 +9,11 @@ filesystems = [
     pytest.param(Rubicon(persistence="memory")),
     pytest.param(
         Rubicon(persistence="filesystem", root_dir="./test-rubicon"),
-        marks=pytest.mark.physical_filesystem_test,
+        marks=pytest.mark.write_files,
     ),
     pytest.param(
         Rubicon(persistence="filesystem", root_dir="s3://change-me"),
-        marks=pytest.mark.physical_filesystem_test,
+        marks=pytest.mark.write_files,
     ),
 ]
 

--- a/tests/notebooks/test_notebooks.py
+++ b/tests/notebooks/test_notebooks.py
@@ -24,7 +24,7 @@ BAD_NOTEBOOK_XFAIL_MARKS = [
 ]
 
 
-@pytest.mark.notebook_test
+@pytest.mark.run_notebooks
 @pytest.mark.parametrize("notebook_filename", NOTEBOOK_FILENAMES + BAD_NOTEBOOK_XFAIL_MARKS)
 def test_notebook_is_executed_in_order(notebook_filename):
     notebook = read_notebook_file(notebook_filename)
@@ -59,7 +59,7 @@ EXECUTE_NOTEBOOK_FILENAMES = [
 
 
 @mock.patch.dict(os.environ, {"RUBICON_ROOT": "test-rubicon-root"})
-@pytest.mark.notebook_test
+@pytest.mark.run_notebooks
 @pytest.mark.parametrize("notebook_filename", EXECUTE_NOTEBOOK_FILENAMES)
 def test_notebooks_execute_without_error(notebook_filename):
     notebook = read_notebook_file(notebook_filename)


### PR DESCRIPTION
## What
  * I noticed the test config and dev docs were a bit outdated while doing #172 
    * removes the `dashboard_test` mark
      * dashboard tests don't require chromium for the time being, so they are no longer gated
    * concise, descriptive names for remaining marks
    * update docs for remaining marks

## How to Test
  * `pytest` should run the notebook tests, but not the file writing tests
  * `pytest -m "not run_notebooks and not write_files"` should not run the notebook tests or the file writing tests
  * `pytest -m "write_files"` should run the notebooks tests and the file writing tests
    * the file writing tests will fail since there is no `--s3-path` provided - this is fine
