### PR TITLE
move `publish` into `intake_rubicon` module

### DIFF
--- a/notebooks/quick-look.ipynb
+++ b/notebooks/quick-look.ipynb
@@ -282,9 +282,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_ = rubicon.publish(\n",
-    "    project.name,\n",
-    "    experiment_tags=[\"success\"],\n",
+    "from rubicon_ml import publish\n",
+    "\n",
+    "\n",
+    "_ = publish(\n",
+    "    project.experiments(tags=[\"success\"]),\n",
     "    output_filepath=\"./wine_catalog.yml\",\n",
     ")"
    ]
@@ -400,7 +402,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.10.2"
   }
  },
  "nbformat": 4,

--- a/rubicon_ml/__init__.py
+++ b/rubicon_ml/__init__.py
@@ -1,4 +1,9 @@
-from rubicon_ml.client import (
+from ._version import get_versions
+
+__version__ = get_versions()["version"]
+del get_versions
+
+from rubicon_ml.client import (  # noqa: E402
     Artifact,
     Dataframe,
     Experiment,
@@ -8,11 +13,7 @@ from rubicon_ml.client import (
     Project,
     Rubicon,
 )
-
-from ._version import get_versions
-
-__version__ = get_versions()["version"]
-del get_versions
+from rubicon_ml.intake_rubicon.publish import publish  # noqa: E402
 
 __all__ = [
     "Artifact",
@@ -22,5 +23,6 @@ __all__ = [
     "Metric",
     "Parameter",
     "Project",
+    "publish",
     "Rubicon",
 ]

--- a/rubicon_ml/intake_rubicon/publish.py
+++ b/rubicon_ml/intake_rubicon/publish.py
@@ -1,0 +1,59 @@
+import fsspec
+import yaml
+
+
+def publish(
+    experiments,
+    output_filepath=None,
+):
+    """Publish experiments to an `intake` catalog that can be
+    read by the `intake-rubicon` driver.
+
+    Parameters
+    ----------
+    experiments : list of rubicon_ml.client.experiment.Experiment
+        The experiments to publish.
+    output_filepath : str, optional
+        The absolute or relative local filepath or S3 bucket
+        and key to log the generated YAML file to. S3 buckets
+        must be prepended with 's3://'. Defaults to None,
+        which disables writing the generated YAML.
+
+    Returns
+    -------
+    str
+        The YAML string representation of the `intake` catalog
+        containing the experiments `experiments`.
+    """
+    catalog = {"sources": {}}
+
+    # TODO: remove when addressing issue #173
+    project = experiments[0].project
+    project_catalog = {
+        "driver": "rubicon_ml_project",
+        "args": {"urlpath": project.repository.root_dir, "project_name": project.name},
+    }
+
+    project_catalog_name = f"project_{project.id.replace('-', '_')}"
+    catalog["sources"][project_catalog_name] = project_catalog
+
+    for experiment in experiments:
+        experiment_catalog = {
+            "driver": "rubicon_ml_experiment",
+            "args": {
+                "experiment_id": experiment.id,
+                "project_name": experiment.project.name,
+                "urlpath": experiment.repository.root_dir,
+            },
+        }
+
+        experiment_catalog_name = f"experiment_{experiment.id.replace('-', '_')}"
+        catalog["sources"][experiment_catalog_name] = experiment_catalog
+
+    catalog_yaml = yaml.dump(catalog)
+
+    if output_filepath is not None:
+        with fsspec.open(output_filepath, "w", auto_mkdir=False) as f:
+            f.write(catalog_yaml)
+
+    return catalog_yaml

--- a/tests/unit/intake_rubicon/test_publish.py
+++ b/tests/unit/intake_rubicon/test_publish.py
@@ -1,0 +1,60 @@
+import fsspec
+import yaml
+
+from rubicon_ml import publish
+
+
+def test_publish(rubicon_and_project_client):
+    rubicon, project = rubicon_and_project_client
+    experiment = project.log_experiment()
+
+    catalog_yaml = publish(project.experiments())
+    catalog = yaml.safe_load(catalog_yaml)
+
+    assert f"project_{project.id.replace('-', '_')}" in catalog["sources"]
+    assert (
+        "rubicon_ml_project"
+        == catalog["sources"][f"project_{project.id.replace('-', '_')}"]["driver"]
+    )
+    assert (
+        project.repository.root_dir
+        == catalog["sources"][f"project_{project.id.replace('-', '_')}"]["args"]["urlpath"]
+    )
+    assert (
+        project.name
+        == catalog["sources"][f"project_{project.id.replace('-', '_')}"]["args"]["project_name"]
+    )
+    assert f"experiment_{experiment.id.replace('-', '_')}" in catalog["sources"]
+    assert (
+        "rubicon_ml_experiment"
+        == catalog["sources"][f"experiment_{experiment.id.replace('-', '_')}"]["driver"]
+    )
+    assert (
+        experiment.repository.root_dir
+        == catalog["sources"][f"experiment_{experiment.id.replace('-', '_')}"]["args"]["urlpath"]
+    )
+    assert (
+        experiment.id
+        == catalog["sources"][f"experiment_{experiment.id.replace('-', '_')}"]["args"][
+            "experiment_id"
+        ]
+    )
+    assert (
+        project.name
+        == catalog["sources"][f"experiment_{experiment.id.replace('-', '_')}"]["args"][
+            "project_name"
+        ]
+    )
+
+
+def test_publish_to_file(rubicon_and_project_client):
+    rubicon, project = rubicon_and_project_client
+    project.log_experiment()
+    project.log_experiment()
+
+    catalog_yaml = publish(project.experiments(), output_filepath="memory://catalog.yml")
+
+    with fsspec.open("memory://catalog.yml", "r") as f:
+        written_catalog = f.read()
+
+    assert catalog_yaml == written_catalog


### PR DESCRIPTION
closes: #172 

---

## What
  * moves the `publish` function off of the `Rubicon` class and into the `intake_rubicon` module
    * updates relevant tests & notebooks
  * rearranges `rubicon_ml.__init__` to avoid circular import

## How to Test
  * validate the new tests in `test_publish.py`
  * validate that you can publish and load from multiple filesystems:

```python
from rubicon_ml import Rubicon, publish

rubicon_a = Rubicon(persistence="filesystem", root_dir="./path/a")
rubicon_b = Rubicon(persistence="filesystem", root_dir="./path/b")
experiment_a = rubicon_a.create_project("test").log_experiment()
experiment_b = rubicon_b.create_project("test").log_experiment()
publish([experiment_a, experiment_b], output_filepath="./test_catalog.yml")

import intake

catalog = intake.open_catalog("./test_catalog.yml")
catalog[list(catalog)[0]].discover()
catalog[list(catalog)[0]].read().repository.root_dir  # should be "./path/a"
catalog[list(catalog)[1]].discover()
catalog[list(catalog)[1]].read().repository.root_dir  # should be "./path/b"
```
