### PR TITLE
`publish` docs

### DIFF
--- a/docs/docs-environment.yml
+++ b/docs/docs-environment.yml
@@ -5,6 +5,7 @@ dependencies:
   - python=3.9
 
   # for building the docs
+  - black
   - furo
   - ipython
   - nbsphinx
@@ -18,5 +19,6 @@ dependencies:
   - dask>=2.12.0
   - pandas>=1.0
   - fsspec>=2021.4.0
+  - intake>=0.5.2
   - prefect>=0.12.0
   - scikit-learn

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -77,6 +77,14 @@ return value.
 
 .. autoclass:: rubicon_ml.client.asynchronous.Rubicon
 
+.. _library-reference-publish:
+
+publish
+=======
+``rubicon_ml`` leverages ``intake`` to easily share sets of experiments.
+
+.. autofunction:: rubicon_ml.publish
+
 .. _library-reference-sklearn:
 
 sklearn


### PR DESCRIPTION
## What
  * docs need the `intake` package in their env now (and `black` for some reason)
