### PR TITLE
python 3.7 deprecation notice

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -22,6 +22,9 @@ Alternatively:
 
     pip install rubicon-ml
 
+.. warning::
+    rubicon-ml version 0.3.0+ requires Python version 3.8+
+
 Extras
 ======
 

--- a/rubicon_ml/sklearn/pipeline.py
+++ b/rubicon_ml/sklearn/pipeline.py
@@ -157,6 +157,7 @@ class RubiconPipeline(Pipeline):
         logger = self.get_estimator_logger()
         logger.log_metric("score", score)
 
+        # clear `self.experiment` to avoid duplicate metric logging errors
         self.experiment = None
 
         return score
@@ -193,6 +194,7 @@ class RubiconPipeline(Pipeline):
 
             logger.log_metric("score_samples", score_samples)
 
+        # clear `self.experiment` to avoid duplicate metric logging errors
         self.experiment = None
 
         return score_samples


### PR DESCRIPTION
closes: #188 

---

## What
  * notes that python 3.7 is deprecated as of rubicon-ml version 0.3.0 in the install docs
