### PR TITLE
update intake dependency to include `msgpack` when using `pip`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
 	click<=8.0.4,>=7.1
 	dask[dataframe]<=2022.02.0,>=2.12.0
 	fsspec<=2022.2.0,>=2021.4.0
-	intake<=0.6.5,>=0.5.2
+	intake[dataframe]<=0.6.5,>=0.5.2
 	pyarrow<=7.0.0,>=0.18.0
 	pyyaml<=6.0,>=5.4.0
 	s3fs<=2022.2.0,>=0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -108,7 +108,7 @@ upgrade =
 	click
 	dask[dataframe]
 	fsspec
-	intake
+	intake[dataframe]
 	pyarrow
 	pyyaml
 	s3fs


### PR DESCRIPTION
closes: #196 

---

## What
  * for some reason the regular intake install doesnt install msgpack even though its [listed in its requirements](https://github.com/intake/intake/blob/master/requirements.txt#L7)
  * installing `intake[dataframe]` fixes this
    * the issue doesn't manifest on conda install as there are no optional dependencies in conda, so the [dataframe] one is always installed