### PR TITLE
versioneer in setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,5 @@
 [metadata]
 name = rubicon-ml
-version = attr: versioneer.get_version
-cmdclass = attr: versioneer.get_cmdclass()
 description = "an ML library for model development and governance"
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -2,4 +2,9 @@
 
 from setuptools import setup
 
-setup()
+import versioneer
+
+setup(
+    version=versioneer.get_version(),
+    cmdclass=versioneer.get_cmdclass(),
+)


### PR DESCRIPTION
## What
  * the most recent release has a nonsense version if you run `rubicon_ml --version` from the command line or `rubicon_ml.__version__` from a python interpreter
  * moves versioneer calls back into setup.py

## How to Test
  * it looked fine locally the last time so I guess we won't know until its released
