### PR TITLE
publish experiments from experiment table

### DIFF
--- a/rubicon_ml/viz/experiments_table.py
+++ b/rubicon_ml/viz/experiments_table.py
@@ -1,7 +1,10 @@
+import os
+
 import dash_bootstrap_components as dbc
 from dash import dash_table, dcc, html
 from dash.dependencies import ALL, Input, Output, State
 
+from rubicon_ml import publish
 from rubicon_ml.viz.base import VizBase
 from rubicon_ml.viz.common.colors import light_blue, plot_background_blue
 
@@ -46,6 +49,16 @@ class ExperimentsTable(VizBase):
                     color="primary",
                     disabled=not self.is_selectable,
                     id="clear-all-button",
+                    outline=True,
+                ),
+                className="bulk-select-button-container",
+            ),
+            html.Div(
+                dbc.Button(
+                    "publish selected",
+                    color="primary",
+                    disabled=not self.is_selectable,
+                    id="publish-selected-button",
                     outline=True,
                 ),
                 className="bulk-select-button-container",
@@ -135,6 +148,29 @@ class ExperimentsTable(VizBase):
             label="toggle columns",
         )
 
+        publish_modal = dbc.Modal(
+            [
+                dbc.ModalHeader(
+                    dbc.ModalTitle("publish selected experiments"),
+                    close_button=True,
+                ),
+                dbc.ModalBody(
+                    [
+                        dbc.Label("catalog YAML output path"),
+                        dbc.Input(
+                            id="publish-path-input",
+                            type="text",
+                            value=os.path.join(os.getcwd(), "rubicon-ml-catalog.yml"),
+                        ),
+                    ],
+                ),
+                dbc.ModalFooter(dbc.Button("publish", id="publish-button")),
+            ],
+            id="publish-modal",
+            centered=True,
+            is_open=False,
+        )
+
         if self.is_selectable:
             header_row = [
                 html.Div(
@@ -170,6 +206,7 @@ class ExperimentsTable(VizBase):
             [
                 *header_row,
                 dcc.Loading(experiment_table, color=light_blue),
+                publish_modal,
             ],
         )
 
@@ -314,3 +351,43 @@ class ExperimentsTable(VizBase):
                 return experiment_table_indices
 
             return []
+
+        @self.app.callback(
+            Output("publish-modal", "is_open"),
+            [
+                Input("publish-selected-button", "n_clicks_timestamp"),
+                Input("publish-button", "n_clicks_timestamp"),
+            ],
+            [
+                State("publish-modal", "is_open"),
+                State("publish-path-input", "value"),
+                State("experiment-table", "derived_virtual_selected_rows"),
+                State("experiment-table", "derived_virtual_data"),
+            ],
+        )
+        def toggle_publish_modal(
+            last_publish_selected_click,
+            last_publish_click,
+            is_modal_open,
+            publish_path,
+            selected_rows,
+            data,
+        ):
+            last_publish_selected_click = (
+                last_publish_selected_click if last_publish_selected_click else 0
+            )
+            last_publish_click = last_publish_click if last_publish_click else 0
+
+            if last_publish_selected_click > last_publish_click:
+                return True
+            elif last_publish_click > last_publish_selected_click:
+                selected_experiment_ids = [data[row].get("id") for row in selected_rows]
+                selected_experiments = [
+                    e for e in self.experiments if e.id in selected_experiment_ids
+                ]
+
+                publish(selected_experiments, publish_path)
+
+                return False
+
+            return is_modal_open

--- a/rubicon_ml/viz/experiments_table.py
+++ b/rubicon_ml/viz/experiments_table.py
@@ -205,8 +205,8 @@ class ExperimentsTable(VizBase):
         return html.Div(
             [
                 *header_row,
-                dcc.Loading(experiment_table, color=light_blue),
                 publish_modal,
+                dcc.Loading(experiment_table, color=light_blue),
             ],
         )
 

--- a/rubicon_ml/viz/experiments_table.py
+++ b/rubicon_ml/viz/experiments_table.py
@@ -20,10 +20,10 @@ class ExperimentsTable(VizBase):
         attribute after instantiation.
     is_selectable : bool, optional
         True to enable selection of the rows in the table, False otherwise.
-        Defaults to False.
+        Defaults to True.
     """
 
-    def __init__(self, experiments=None, is_selectable=False):
+    def __init__(self, experiments=None, is_selectable=True):
         super().__init__(dash_title="experiment table")
 
         self.experiments = experiments

--- a/rubicon_ml/viz/experiments_table.py
+++ b/rubicon_ml/viz/experiments_table.py
@@ -156,7 +156,7 @@ class ExperimentsTable(VizBase):
                 ),
                 dbc.ModalBody(
                     [
-                        dbc.Label("catalog YAML output path"),
+                        dbc.Label("enter catalog YAML output path:"),
                         dbc.Input(
                             id="publish-path-input",
                             type="text",
@@ -169,6 +169,7 @@ class ExperimentsTable(VizBase):
             id="publish-modal",
             centered=True,
             is_open=False,
+            size="lg",
         )
 
         if self.is_selectable:

--- a/tests/unit/viz/test_experiments_table.py
+++ b/tests/unit/viz/test_experiments_table.py
@@ -39,17 +39,19 @@ def test_experiments_table_layout(viz_experiments):
     experiments_table.load_experiment_data()
     layout = experiments_table.layout
 
-    assert len(layout.children) == 2
+    assert len(layout.children) == 4
     assert layout.children[-1].children.id == "experiment-table"
+    assert layout.children[-2].id == "publish-modal"
 
 
-def test_experiments_table_layout_selectable(viz_experiments):
-    experiments_table = ExperimentsTable(experiments=viz_experiments, is_selectable=True)
+def test_experiments_table_layout_not_selectable(viz_experiments):
+    experiments_table = ExperimentsTable(experiments=viz_experiments, is_selectable=False)
     experiments_table.load_experiment_data()
     layout = experiments_table.layout
 
     assert len(layout.children) == 3
     assert layout.children[-1].children.id == "experiment-table"
+    assert layout.children[-2].id == "publish-modal"
 
 
 def test_experiments_table_register_callbacks(viz_experiments):
@@ -59,10 +61,11 @@ def test_experiments_table_register_callbacks(viz_experiments):
 
     callback_values = list(experiments_table.app.callback_map.values())
 
-    assert len(callback_values) == 3
+    assert len(callback_values) == 4
 
     registered_callback_names = [callback["callback"].__name__ for callback in callback_values]
 
     assert "update_selected_column_checkboxes" in registered_callback_names
     assert "update_hidden_experiment_table_cols" in registered_callback_names
     assert "update_selected_experiment_table_rows" in registered_callback_names
+    assert "toggle_publish_modal" in registered_callback_names


### PR DESCRIPTION
## What
  * adds a button to the experiment table visualization that allows users to publish a catalog of selected experiments
    * adds a modal triggered by the button that allows input to define a catalog output path
  * updates tests to reflect changes

## How to Test
  * run the experiment table notebook and validate that the publish button writes a catalog of the selected experiments to the location you gave it
