### PR TITLE
try to pass whitesource

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -4,5 +4,8 @@
   },
   "issueSettings": {
     "minSeverityLevel": "LOW"
+  },
+  "scanSettings": {
+    "configMode": "LOCAL"
   }
 }


### PR DESCRIPTION
## What
  * whitesource is falsely reporting numpy 1.21 despite numpy 1.22 being present in the locally created environment

## How to Test
  * hope the whitesource scan passes
    * the changes to `.whitesource` may not be applied until it gets to main, so we may need to merge this and then test
