### PR TITLE
add python-kaleido to edgetest testing requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -99,6 +99,7 @@ conda_install =
 	scikit-learn
 	pytest
 	pytest-cov
+	python-kaleido
 extras = 
 	all
 upgrade = 


### PR DESCRIPTION
## What
  * the edgetest action is failing after #218 
    * adds `python-kaleido` to the edgetest testing requirements

## How to Test
  * wait for the action to run tonight
