### PR TITLE
Fixing PIL/kaleido issues for edgetest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -91,6 +91,9 @@ xfail_strict = True
 
 [edgetest.envs.core]
 python_version = 3.9
+deps =
+    	kaleido
+	Pillow
 conda_install = 
 	jupyterlab
 	nodejs
@@ -99,7 +102,6 @@ conda_install =
 	scikit-learn
 	pytest
 	pytest-cov
-	python-kaleido
 extras = 
 	all
 upgrade = 


### PR DESCRIPTION
closes: #228

---

## What
  * Fixes the dependencies for unit tests to run and cause edgetest to pass.

