### PR TITLE
use `conda` in `edgetest`

### DIFF
--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -5,6 +5,8 @@ name: Run edgetest
 on:
   schedule:
     - cron: '0 10 * * 1-5'
+  workflow_dispatch:
+
 jobs:
   edgetest:
     runs-on: ubuntu-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,20 +91,20 @@ xfail_strict = True
 
 [edgetest.envs.core]
 python_version = 3.9
-deps = 
-	kaleido
-	Pillow
-	shap
-	numba
-	matplotlib
 conda_install = 
 	jupyterlab
-	nodejs
+	matplotlib
 	nbconvert
 	nbformat
-	scikit-learn
+	nodejs
+	numba
+	pillow
 	pytest
 	pytest-cov
+	python-kaleido
+	r-palmerpenguins
+	scikit-learn
+	shap
 extras = 
 	all
 upgrade = 
@@ -119,4 +119,4 @@ upgrade =
 	prefect
 	dash
 	dash-bootstrap-components
-
+update_with_conda = True


### PR DESCRIPTION
closes: #252 
---

## What
  * updates edgetest to use the `update_with_conda` flag recently introduced in [edgetest-conda](https://github.com/capitalone/edgetest-conda/)
    * this should resolve the missing dependency noted in #252 
  * adds the `workflow_dispatch` trigger to the edgetest workflow so future changes can be tested off-schedule

## How to Test
 I think we'll need to merge before we can test, unless the `workflow_dispatch` trigger shows up just via the PR
  * yeah this looks to be the case - I dont see the `workflow_dispatch` dropdown on the edgetest action yet