### PR TITLE
revert `edgetest` action changes

### DIFF
--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           ref: main
       - id: run-edgetest
-        uses: fdosani/run-edgetest-action@v1.1
+        uses: fdosani/run-edgetest-action@v1.2
         with:
           edgetest-flags: '-c setup.cfg --export'
           base-branch: 'main'

--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -5,6 +5,8 @@ name: Run edgetest
 on:
   schedule:
     - cron: '0 10 * * 1-5'
+  workflow_dispatch:
+
 jobs:
   edgetest:
     runs-on: ubuntu-latest

--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -5,8 +5,6 @@ name: Run edgetest
 on:
   schedule:
     - cron: '0 10 * * 1-5'
-  workflow_dispatch:
-
 jobs:
   edgetest:
     runs-on: ubuntu-latest
@@ -16,7 +14,7 @@ jobs:
         with:
           ref: main
       - id: run-edgetest
-        uses: fdosani/run-edgetest-action@v1.2
+        uses: fdosani/run-edgetest-action@v1.1
         with:
           edgetest-flags: '-c setup.cfg --export'
           base-branch: 'main'

--- a/setup.cfg
+++ b/setup.cfg
@@ -119,4 +119,3 @@ upgrade =
 	prefect
 	dash
 	dash-bootstrap-components
-update_with_conda = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,13 +91,13 @@ xfail_strict = True
 
 [edgetest.envs.core]
 python_version = 3.9
-deps =
+deps = 
 	kaleido
 	Pillow
 	shap
-	matplotlib
 	numba
-conda_install =
+	matplotlib
+conda_install = 
 	jupyterlab
 	nodejs
 	nbconvert
@@ -119,3 +119,4 @@ upgrade =
 	prefect
 	dash
 	dash-bootstrap-components
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,19 +93,18 @@ xfail_strict = True
 python_version = 3.9
 deps =
 	kaleido
-	matplotlib
-	numba
-	palmerpenguins
 	Pillow
 	shap
+	matplotlib
+	numba
 conda_install =
 	jupyterlab
+	nodejs
 	nbconvert
 	nbformat
-	nodejs
+	scikit-learn
 	pytest
 	pytest-cov
-	scikit-learn
 extras = 
 	all
 upgrade = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,20 +91,21 @@ xfail_strict = True
 
 [edgetest.envs.core]
 python_version = 3.9
-conda_install = 
-	jupyterlab
+deps =
+	kaleido
 	matplotlib
+	numba
+	palmerpenguins
+	Pillow
+	shap
+conda_install =
+	jupyterlab
 	nbconvert
 	nbformat
 	nodejs
-	numba
-	pillow
 	pytest
 	pytest-cov
-	python-kaleido
-	r-palmerpenguins
 	scikit-learn
-	shap
 extras = 
 	all
 upgrade = 


### PR DESCRIPTION
## What
  * the updates to edgetest in #253 are behaving unexpectedly - this reverts them
    * except for the manual workflow trigger

## How to Test
  * proof that this reverted everything except for the trigger: https://github.com/capitalone/rubicon-ml/compare/f867fb1...fe63f3a
  * merge and run the action
