### PR TITLE
edgetest update

### DIFF
--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: main
+          fetch-depth: 0
       - id: run-edgetest
         uses: fdosani/run-edgetest-action@v1.1
         with:

--- a/docs/docs-environment.yml
+++ b/docs/docs-environment.yml
@@ -24,7 +24,7 @@ dependencies:
   - dash<=2.6.0,>=2.0.0
   - dash-bootstrap-components<=1.2.0,>=1.0.0
   - dask[dataframe]<=2022.7.1,>=2.12.0
-  - fsspec<=2022.5.0,>=2021.4.0
+  - fsspec<=2022.7.0,>=2021.4.0
   - intake[dataframe]<=0.6.5,>=0.5.2
   - pandas<=1.4.3,>=1.0.0
   - prefect<=1.2.4,>=0.12.0

--- a/docs/docs-environment.yml
+++ b/docs/docs-environment.yml
@@ -21,13 +21,13 @@ dependencies:
 
   # install rubicon-ml dependencies
   # so local pip install doesn't
-  - dash<=2.5.1,>=2.0.0
+  - dash<=2.6.0,>=2.0.0
   - dash-bootstrap-components<=1.2.0,>=1.0.0
-  - dask[dataframe]<=2022.6.1,>=2.12.0
+  - dask[dataframe]<=2022.7.1,>=2.12.0
   - fsspec<=2022.5.0,>=2021.4.0
   - intake[dataframe]<=0.6.5,>=0.5.2
   - pandas<=1.4.3,>=1.0.0
-  - prefect<=1.2.3,>=0.12.0
+  - prefect<=1.2.4,>=0.12.0
   - pyarrow<=8.0.0,>=0.18.0
   - PyYAML<=6.0,>=5.4.0
   - scikit-learn

--- a/environment.yml
+++ b/environment.yml
@@ -7,12 +7,12 @@ dependencies:
 
   - click<=8.1.3,>=7.1
   - dask[dataframe]<=2022.7.1,>=2.12.0
-  - fsspec<=2022.5.0,>=2021.4.0
+  - fsspec<=2022.7.0,>=2021.4.0
   - intake[dataframe]<=0.6.5,>=0.5.2
   - pandas<=1.4.3,>=1.0.0
   - pyarrow<=8.0.0,>=0.18.0
   - PyYAML<=6.0,>=5.4.0
-  - s3fs<=2022.5.0,>=0.4
+  - s3fs<=2022.7.0,>=0.4
 
   # for prefect workflows
   - prefect<=1.2.4,>=0.12.0

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - pip
 
   - click<=8.1.3,>=7.1
-  - dask[dataframe]<=2022.6.1,>=2.12.0
+  - dask[dataframe]<=2022.7.1,>=2.12.0
   - fsspec<=2022.5.0,>=2021.4.0
   - intake[dataframe]<=0.6.5,>=0.5.2
   - pandas<=1.4.3,>=1.0.0
@@ -15,10 +15,10 @@ dependencies:
   - s3fs<=2022.5.0,>=0.4
 
   # for prefect workflows
-  - prefect<=1.2.3,>=0.12.0
+  - prefect<=1.2.4,>=0.12.0
 
   # for viz
-  - dash<=2.5.1,>=2.0.0
+  - dash<=2.6.0,>=2.0.0
   - dash-bootstrap-components<=1.2.0,>=1.0.0
 
   # for scikit-learn integration

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,12 +30,12 @@ packages = find:
 install_requires = 
 	click<=8.1.3,>=7.1
 	dask[dataframe]<=2022.7.1,>=2.12.0
-	fsspec<=2022.5.0,>=2021.4.0
+	fsspec<=2022.7.0,>=2021.4.0
 	intake[dataframe]<=0.6.5,>=0.5.2
 	pandas<=1.4.3,>=1.0.0
 	pyarrow<=8.0.0,>=0.18.0
 	PyYAML<=6.0,>=5.4.0
-	s3fs<=2022.5.0,>=0.4
+	s3fs<=2022.7.0,>=0.4
 
 [options.extras_require]
 prefect_requires = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ include_package_data = True
 packages = find:
 install_requires = 
 	click<=8.1.3,>=7.1
-	dask[dataframe]<=2022.6.1,>=2.12.0
+	dask[dataframe]<=2022.7.1,>=2.12.0
 	fsspec<=2022.5.0,>=2021.4.0
 	intake[dataframe]<=0.6.5,>=0.5.2
 	pandas<=1.4.3,>=1.0.0
@@ -39,13 +39,13 @@ install_requires =
 
 [options.extras_require]
 prefect_requires = 
-	prefect<=1.2.3,>=0.12.0
+	prefect<=1.2.4,>=0.12.0
 ui_requires = 
-	dash<=2.5.1,>=2.0.0
+	dash<=2.6.0,>=2.0.0
 	dash-bootstrap-components<=1.2.0,>=1.0.0
 all = 
-	prefect<=1.2.3,>=0.12.0
-	dash<=2.5.1,>=2.0.0
+	prefect<=1.2.4,>=0.12.0
+	dash<=2.6.0,>=2.0.0
 	dash-bootstrap-components<=1.2.0,>=1.0.0
 
 [options.entry_points]
@@ -104,6 +104,7 @@ conda_install =
 	nbconvert
 	nbformat
 	scikit-learn
+	prefect  # >=2.0.0 incompatible w/ tests
 	pytest
 	pytest-cov
 extras = 
@@ -117,7 +118,6 @@ upgrade =
 	pyarrow
 	PyYAML
 	s3fs
-	prefect
 	dash
 	dash-bootstrap-components
 


### PR DESCRIPTION
## What
  * applies the good version updates from https://github.com/capitalone/rubicon-ml/pull/256
    * that PR was opened a few days ago and eventually closed itself because `prefect` v2.0.0 caused tests to start failing
    * only applies the updates before `prefect` v2.0.0
  * moves `prefect` from the `update` section of the `edgetest` config to the `conda_install` section
    * this will no longer attempt to update `prefect`, effectively locking it in at less than v2.0.0
    * we can revisit this later if necessary
  * removes the `ref: main` tag from the checkout action so the manual trigger can select non-main branches
  * applies the version updates from https://github.com/capitalone/rubicon-ml/pull/258
    * these were generated after fixing the manual trigger and getting a successful test run

## How to Test
  * original tests on https://github.com/capitalone/rubicon-ml/pull/256 already passed
  * RESOLVED ~manually triggering the workflow seems to always run off of main regardless of what branch is selected, so we'll have to wait until the action is merged to test it~
    * ~I've reached out to the `edgetest` team to see how to properly run against non-main branches~
  * [the action successfully ran against this new branch](https://github.com/capitalone/rubicon-ml/runs/7561040207?check_suite_focus=true)