### PR TITLE
fix whitesource failures

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
 	dask[dataframe]<=2022.8.1,>=2.12.0
 	fsspec<=2022.7.1,>=2021.4.0
 	intake[dataframe]<=0.6.5,>=0.5.2
-	numpy<=1.22.4,>=1.22.0
+	numpy<=1.23.2,>=1.22.0
 	pandas<=1.4.3,>=1.0.0
 	pyarrow<=9.0.0,>=0.18.0
 	PyYAML<=6.0,>=5.4.0
@@ -110,8 +110,6 @@ conda_install =
 	pytest
 	pytest-cov
 	# frozen dependencies
-	numpy  # >=1.23.0 currently incompatible with `numba` (should be resolved soon)
-	       # https://github.com/numba/numba/issues/8263
 	prefect  # >=2.0.0 introduces breaking changes
 extras = 
 	all
@@ -122,6 +120,7 @@ upgrade =
 	dask[dataframe]
 	fsspec
 	intake[dataframe]
+	numpy
 	pandas
 	pyarrow
 	PyYAML

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ install_requires =
 	dask[dataframe]<=2022.8.1,>=2.12.0
 	fsspec<=2022.7.1,>=2021.4.0
 	intake[dataframe]<=0.6.5,>=0.5.2
-	numpy<=1.23.2,>=1.22.0
 	pandas<=1.4.3,>=1.0.0
 	pyarrow<=9.0.0,>=0.18.0
 	PyYAML<=6.0,>=5.4.0
@@ -45,10 +44,12 @@ prefect_requires =
 ui_requires = 
 	dash<=2.6.1,>=2.0.0
 	dash-bootstrap-components<=1.2.1,>=1.0.0
+	numpy<=1.23.2,>=1.22.0
 all = 
 	prefect<=1.2.4,>=0.12.0
 	dash<=2.6.1,>=2.0.0
 	dash-bootstrap-components<=1.2.1,>=1.0.0
+	numpy<=1.23.2,>=1.22.0
 
 [options.entry_points]
 console_scripts = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,10 +46,10 @@ ui_requires =
 	dash-bootstrap-components<=1.2.1,>=1.0.0
 	numpy<=1.23.2,>=1.22.0
 all = 
-	prefect<=1.2.4,>=0.12.0
 	dash<=2.6.1,>=2.0.0
 	dash-bootstrap-components<=1.2.1,>=1.0.0
 	numpy<=1.23.2,>=1.22.0
+	prefect<=1.2.4,>=0.12.0
 
 [options.entry_points]
 console_scripts = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
 	dask[dataframe]<=2022.8.1,>=2.12.0
 	fsspec<=2022.7.1,>=2021.4.0
 	intake[dataframe]<=0.6.5,>=0.5.2
-	numpy<=1.23.2,>=1.22.0
+	numpy<=1.22.4,>=1.22.0
 	pandas<=1.4.3,>=1.0.0
 	pyarrow<=9.0.0,>=0.18.0
 	PyYAML<=6.0,>=5.4.0
@@ -110,7 +110,9 @@ conda_install =
 	pytest
 	pytest-cov
 	# frozen dependencies
-	prefect  # >=2.0.0 incompatible w/ current tests
+	numpy  # >=1.23.0 currently incompatible with `numba` (should be resolved soon)
+	       # https://github.com/numba/numba/issues/8263
+	prefect  # >=2.0.0 introduces breaking changes
 extras = 
 	all
 upgrade = 
@@ -120,7 +122,6 @@ upgrade =
 	dask[dataframe]
 	fsspec
 	intake[dataframe]
-	numpy
 	pandas
 	pyarrow
 	PyYAML

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,10 +32,12 @@ install_requires =
 	dask[dataframe]<=2022.8.1,>=2.12.0
 	fsspec<=2022.7.1,>=2021.4.0
 	intake[dataframe]<=0.6.5,>=0.5.2
+	numpy<=1.23.2,>=1.22.0
 	pandas<=1.4.3,>=1.0.0
 	pyarrow<=9.0.0,>=0.18.0
 	PyYAML<=6.0,>=5.4.0
 	s3fs<=2022.7.1,>=0.4
+	scikit-learn<=1.1.2,>=0.22.0
 
 [options.extras_require]
 prefect_requires = 
@@ -92,6 +94,7 @@ xfail_strict = True
 [edgetest.envs.core]
 python_version = 3.9
 deps = 
+	# additional testing requirements
 	kaleido
 	Pillow
 	shap
@@ -99,25 +102,27 @@ deps =
 	matplotlib
 	palmerpenguins
 conda_install = 
+	# testing infrastructure
 	jupyterlab
 	nodejs
 	nbconvert
 	nbformat
-	scikit-learn
-	prefect  # >=2.0.0 incompatible w/ tests
 	pytest
 	pytest-cov
+	# frozen dependencies
+	prefect  # >=2.0.0 incompatible w/ current tests
 extras = 
 	all
 upgrade = 
 	click
+	dash
+	dash-bootstrap-components
 	dask[dataframe]
 	fsspec
 	intake[dataframe]
+	numpy
 	pandas
 	pyarrow
 	PyYAML
 	s3fs
-	dash
-	dash-bootstrap-components
-
+	scikit-learn


### PR DESCRIPTION
## What
  * adds `numpy` to setup.cfg and edgetest config to hopefully stop whitesource from [failing](https://github.com/capitalone/rubicon-ml/runs/7952837318)
    * ~`numpy` 1.23 is not yet compatible with `numba`, so we're pinned to 1.22 only here rn~
      * ~looks like it should be soon (https://github.com/numba/numba/issues/8263)~
      * addressed by `numba`
  * also adds `scikit-learn` since it was the only other top-level dependency not present other than `numpy`

## How to Test
  * I confirmed that the `numpy` and `sklearn` lower bounds pass tests with the python version lower bound
  * [edgetest is passing](https://github.com/capitalone/rubicon-ml/runs/8255712989?check_suite_focus=true)