### PR TITLE
fix intake test

### DIFF
--- a/tests/unit/intake_rubicon/test_experiment.py
+++ b/tests/unit/intake_rubicon/test_experiment.py
@@ -4,7 +4,7 @@ import intake
 
 from rubicon_ml.intake_rubicon.experiment import ExperimentSource
 
-intake.register_driver("rubicon_ml_experiment", ExperimentSource)
+intake.register_driver("rubicon_ml_experiment", ExperimentSource, clobber=True)
 
 root = os.path.dirname(__file__)
 project_name = "intake-rubicon unit testing"

--- a/tests/unit/intake_rubicon/test_experiment.py
+++ b/tests/unit/intake_rubicon/test_experiment.py
@@ -4,8 +4,6 @@ import intake
 
 from rubicon_ml.intake_rubicon.experiment import ExperimentSource
 
-intake.register_driver("rubicon_ml_experiment", ExperimentSource, clobber=True)
-
 root = os.path.dirname(__file__)
 project_name = "intake-rubicon unit testing"
 experiment_id = "5f6ca6a1-563f-4f34-a34b-b45997bc4a1f"


### PR DESCRIPTION
## What
  * an update in `intake` 0.6.6 is causing the tests to [fail in the `edgetest` action](https://github.com/capitalone/rubicon-ml/runs/8246696007?check_suite_focus=true)
    * the action looks like its passing, but expand the "run-edgetest-action" dropdown to see the failure on test initialization
  * removes the call to `register_driver` in the test
    * the driver is already registered once when the submodule is initialized
    * 0.6.6 exposes a `clobber` keyword argument to `register_driver` that defaults to False, causing the error we're seeing when the driver is re-registered in the test

## How to Test
  * I'll manually run the `edgetest` action off this branch and post below when its done
    * https://github.com/capitalone/rubicon-ml/actions/runs/3016718221
