### PR TITLE
add tagging to artifacts

### DIFF
--- a/rubicon_ml/client/artifact.py
+++ b/rubicon_ml/client/artifact.py
@@ -2,7 +2,7 @@ import os
 
 import fsspec
 
-from rubicon_ml.client import Base
+from rubicon_ml.client.base import Base
 from rubicon_ml.client.mixin import MultiParentMixin, TagMixin
 
 

--- a/rubicon_ml/client/artifact.py
+++ b/rubicon_ml/client/artifact.py
@@ -3,9 +3,10 @@ import os
 import fsspec
 
 from rubicon_ml.client import Base
+from rubicon_ml.client.mixin import MultiParentMixin, TagMixin
 
 
-class Artifact(Base):
+class Artifact(Base, MultiParentMixin, TagMixin):
     """A client artifact.
 
     An `artifact` is a catch-all for any other type of

--- a/rubicon_ml/client/artifact.py
+++ b/rubicon_ml/client/artifact.py
@@ -3,10 +3,10 @@ import os
 import fsspec
 
 from rubicon_ml.client.base import Base
-from rubicon_ml.client.mixin import MultiParentMixin, TagMixin
+from rubicon_ml.client.mixin import TagMixin
 
 
-class Artifact(Base, MultiParentMixin, TagMixin):
+class Artifact(Base, TagMixin):
     """A client artifact.
 
     An `artifact` is a catch-all for any other type of

--- a/rubicon_ml/client/artifact.py
+++ b/rubicon_ml/client/artifact.py
@@ -36,7 +36,7 @@ class Artifact(Base, TagMixin):
 
     def _get_data(self):
         """Loads the data associated with this artifact."""
-        project_name, experiment_id = self.parent._get_parent_identifiers()
+        project_name, experiment_id = self.parent._get_identifiers()
 
         self._data = self.repository.get_artifact_data(
             project_name, self.id, experiment_id=experiment_id

--- a/rubicon_ml/client/asynchronous/artifact.py
+++ b/rubicon_ml/client/asynchronous/artifact.py
@@ -29,7 +29,7 @@ class Artifact(SyncArtifact):
         """Overrides `rubicon.client.Artifact._get_data` to
         asynchronously load the data associated with this artifact.
         """
-        project_name, experiment_id = self.parent._get_parent_identifiers()
+        project_name, experiment_id = self.parent._get_identifiers()
 
         self._data = await self.repository.get_artifact_data(
             project_name, self.id, experiment_id=experiment_id

--- a/rubicon_ml/client/asynchronous/mixin.py
+++ b/rubicon_ml/client/asynchronous/mixin.py
@@ -65,7 +65,7 @@ class ArtifactMixin:
 
         artifact = domain.Artifact(name=name, description=description, parent_id=self._domain.id)
 
-        project_name, experiment_id = self._get_parent_identifiers()
+        project_name, experiment_id = self._get_identifiers()
         await self.repository.create_artifact(
             artifact, data_bytes, project_name, experiment_id=experiment_id
         )
@@ -129,7 +129,7 @@ class ArtifactMixin:
         list of rubicon.client.Artifact
             The artifacts previously logged to this client object.
         """
-        project_name, experiment_id = self._get_parent_identifiers()
+        project_name, experiment_id = self._get_identifiers()
 
         self._artifacts = [
             client.Artifact(a, self)
@@ -150,7 +150,7 @@ class ArtifactMixin:
         ids : list of str
             The ids of the artifacts to delete.
         """
-        project_name, experiment_id = self._get_parent_identifiers()
+        project_name, experiment_id = self._get_identifiers()
 
         await asyncio.gather(
             *[
@@ -186,7 +186,7 @@ class DataframeMixin:
         """
         dataframe = domain.Dataframe(parent_id=self._domain.id, description=description, tags=tags)
 
-        project_name, experiment_id = self._get_parent_identifiers()
+        project_name, experiment_id = self._get_identifiers()
         await self.repository.create_dataframe(
             dataframe, df, project_name, experiment_id=experiment_id
         )
@@ -225,7 +225,7 @@ class DataframeMixin:
         list of rubicon.client.Dataframe
             The dataframes previously logged to this client object.
         """
-        project_name, experiment_id = self._get_parent_identifiers()
+        project_name, experiment_id = self._get_identifiers()
         dataframes = [
             client.Dataframe(d, self)
             for d in await self.repository.get_dataframes_metadata(
@@ -247,7 +247,7 @@ class DataframeMixin:
         ids : list of str
             The ids of the dataframes to delete.
         """
-        project_name, experiment_id = self._get_parent_identifiers()
+        project_name, experiment_id = self._get_identifiers()
 
         await asyncio.gather(
             *[

--- a/rubicon_ml/client/asynchronous/mixin.py
+++ b/rubicon_ml/client/asynchronous/mixin.py
@@ -3,11 +3,10 @@ from datetime import datetime
 
 from rubicon_ml import domain
 from rubicon_ml.client import asynchronous as client
-from rubicon_ml.client.mixin import MultiParentMixin
 from rubicon_ml.client.utils.tags import has_tag_requirements
 
 
-class ArtifactMixin(MultiParentMixin):
+class ArtifactMixin:
     """Adds artifact support to an asynchronous client object."""
 
     async def log_artifact(
@@ -163,7 +162,7 @@ class ArtifactMixin(MultiParentMixin):
         )
 
 
-class DataframeMixin(MultiParentMixin):
+class DataframeMixin:
     """Adds dataframe support to an asynchronous client object."""
 
     async def log_dataframe(self, df, description=None, tags=[]):

--- a/rubicon_ml/client/dataframe.py
+++ b/rubicon_ml/client/dataframe.py
@@ -41,7 +41,7 @@ class Dataframe(Base, TagMixin):
             The type of dataframe. Can be either `pandas` or `dask`.
             Defaults to 'pandas'.
         """
-        project_name, experiment_id = self.parent._get_parent_identifiers()
+        project_name, experiment_id = self.parent._get_identifiers()
 
         self._data = self.repository.get_dataframe_data(
             project_name,

--- a/rubicon_ml/client/experiment.py
+++ b/rubicon_ml/client/experiment.py
@@ -37,7 +37,8 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
         self._features = []
         self._parameters = []
 
-    def _get_parent_identifiers(self):
+    def _get_identifiers(self):
+        """Get the experiment's project's name and the experiment's ID."""
         return self.project.name, self.id
 
     def log_metric(self, name, value, directionality="score", description=None):

--- a/rubicon_ml/client/experiment.py
+++ b/rubicon_ml/client/experiment.py
@@ -37,6 +37,9 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
         self._features = []
         self._parameters = []
 
+    def _get_parent_identifiers(self):
+        return self.project.name, self.id
+
     def log_metric(self, name, value, directionality="score", description=None):
         """Create a metric under the experiment.
 

--- a/rubicon_ml/client/mixin.py
+++ b/rubicon_ml/client/mixin.py
@@ -108,7 +108,7 @@ class ArtifactMixin:
             tags=tags,
         )
 
-        project_name, experiment_id = self._get_parent_identifiers()
+        project_name, experiment_id = self._get_identifiers()
         self.repository.create_artifact(
             artifact, data_bytes, project_name, experiment_id=experiment_id
         )
@@ -196,7 +196,7 @@ class ArtifactMixin:
         list of rubicon.client.Artifact
             The artifacts previously logged to this client object.
         """
-        project_name, experiment_id = self._get_parent_identifiers()
+        project_name, experiment_id = self._get_identifiers()
         self._artifacts = [
             client.Artifact(a, self)
             for a in self.repository.get_artifacts_metadata(
@@ -239,7 +239,7 @@ class ArtifactMixin:
 
             artifact = artifacts[-1]
         else:
-            project_name, experiment_id = self._get_parent_identifiers()
+            project_name, experiment_id = self._get_identifiers()
             artifact = client.Artifact(
                 self.repository.get_artifact_metadata(project_name, id, experiment_id), self
             )
@@ -255,7 +255,7 @@ class ArtifactMixin:
         ids : list of str
             The ids of the artifacts to delete.
         """
-        project_name, experiment_id = self._get_parent_identifiers()
+        project_name, experiment_id = self._get_identifiers()
 
         for artifact_id in ids:
             self.repository.delete_artifact(project_name, artifact_id, experiment_id=experiment_id)
@@ -289,7 +289,7 @@ class DataframeMixin:
             tags=tags,
         )
 
-        project_name, experiment_id = self._get_parent_identifiers()
+        project_name, experiment_id = self._get_identifiers()
         self.repository.create_dataframe(dataframe, df, project_name, experiment_id=experiment_id)
 
         return client.Dataframe(dataframe, self)
@@ -330,7 +330,7 @@ class DataframeMixin:
         list of rubicon.client.Dataframe
             The dataframes previously logged to this client object.
         """
-        project_name, experiment_id = self._get_parent_identifiers()
+        project_name, experiment_id = self._get_identifiers()
         dataframes = [
             client.Dataframe(d, self)
             for d in self.repository.get_dataframes_metadata(
@@ -373,7 +373,7 @@ class DataframeMixin:
 
             dataframe = dataframes[-1]
         else:
-            project_name, experiment_id = self._get_parent_identifiers()
+            project_name, experiment_id = self._get_identifiers()
             dataframe = client.Dataframe(
                 self.repository.get_dataframe_metadata(
                     project_name, experiment_id=experiment_id, dataframe_id=id
@@ -392,7 +392,7 @@ class DataframeMixin:
         ids : list of str
             The ids of the dataframes to delete.
         """
-        project_name, experiment_id = self._get_parent_identifiers()
+        project_name, experiment_id = self._get_identifiers()
 
         for dataframe_id in ids:
             self.repository.delete_dataframe(
@@ -407,12 +407,12 @@ class TagMixin:
         entity_id = None
 
         if isinstance(self, client.Project):
-            project_name, experiment_id = self._get_parent_identifiers()
+            project_name, experiment_id = self._get_identifiers()
         elif isinstance(self, client.Experiment):
-            project_name, _ = self._get_parent_identifiers()
+            project_name, _ = self._get_identifiers()
             experiment_id = self.id
         else:
-            project_name, experiment_id = self._parent._get_parent_identifiers()
+            project_name, experiment_id = self._parent._get_identifiers()
             entity_id = self.id
 
         return project_name, experiment_id, entity_id

--- a/rubicon_ml/client/mixin.py
+++ b/rubicon_ml/client/mixin.py
@@ -404,15 +404,13 @@ class TagMixin:
     """Adds tag support to a client object."""
 
     def _get_taggable_identifiers(self):
+        project_name, experiment_id = self._parent._get_identifiers()
         entity_id = None
 
-        if isinstance(self, client.Project):
-            project_name, experiment_id = self._get_identifiers()
-        elif isinstance(self, client.Experiment):
-            project_name, _ = self._get_identifiers()
+        # experiments are not required to return an entity ID - they are the entity
+        if isinstance(self, client.Experiment):
             experiment_id = self.id
         else:
-            project_name, experiment_id = self._parent._get_identifiers()
             entity_id = self.id
 
         return project_name, experiment_id, entity_id

--- a/rubicon_ml/client/mixin.py
+++ b/rubicon_ml/client/mixin.py
@@ -428,8 +428,11 @@ class TagMixin:
 
         if isinstance(self, client.Project):
             project_name, experiment_id = self._get_parent_identifiers()
+        elif isinstance(self, client.Experiment):
+            project_name, _ = self._get_parent_identifiers()
+            experiment_id = self.id
         else:
-            project_name, experiment_id = self.parent._get_parent_identifiers()
+            project_name, experiment_id = self._parent._get_parent_identifiers()
             entity_id = self.id
 
         return project_name, experiment_id, entity_id

--- a/rubicon_ml/client/mixin.py
+++ b/rubicon_ml/client/mixin.py
@@ -10,27 +10,7 @@ from rubicon_ml.client.utils.tags import has_tag_requirements
 from rubicon_ml.exceptions import RubiconException
 
 
-class MultiParentMixin:
-    """Adds utils for client objects that can be logged
-    to either a `Project` or `Experiment`.
-    """
-
-    def _get_parent_identifiers(self):
-        """Get the project name and experiment ID (or
-        `None`) of this client object's parent(s).
-        """
-        experiment_id = None
-
-        if isinstance(self, client.Project):
-            project_name = self.name
-        else:
-            project_name = self.project.name
-            experiment_id = self.id
-
-        return project_name, experiment_id
-
-
-class ArtifactMixin(MultiParentMixin):
+class ArtifactMixin:
     """Adds artifact support to a client object."""
 
     def _validate_data(self, data_bytes, data_file, data_path, name):
@@ -281,7 +261,7 @@ class ArtifactMixin(MultiParentMixin):
             self.repository.delete_artifact(project_name, artifact_id, experiment_id=experiment_id)
 
 
-class DataframeMixin(MultiParentMixin):
+class DataframeMixin:
     """Adds dataframe support to a client object."""
 
     def log_dataframe(self, df, description=None, name=None, tags=[]):

--- a/rubicon_ml/client/project.py
+++ b/rubicon_ml/client/project.py
@@ -49,7 +49,8 @@ class Project(Base, ArtifactMixin, DataframeMixin):
 
         return completed_process.stdout.decode("utf8").replace("\n", "")
 
-    def _get_parent_identifiers(self):
+    def _get_identifiers(self):
+        """Get the project's name."""
         return self.name, None
 
     def _create_experiment_domain(

--- a/rubicon_ml/client/project.py
+++ b/rubicon_ml/client/project.py
@@ -49,6 +49,9 @@ class Project(Base, ArtifactMixin, DataframeMixin):
 
         return completed_process.stdout.decode("utf8").replace("\n", "")
 
+    def _get_parent_identifiers(self):
+        return self.name, None
+
     def _create_experiment_domain(
         self,
         name,

--- a/rubicon_ml/domain/artifact.py
+++ b/rubicon_ml/domain/artifact.py
@@ -2,16 +2,19 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import List
 
+from rubicon_ml.domain.mixin import TagMixin
 from rubicon_ml.domain.utils import uuid
 
 
 @dataclass
-class Artifact:
+class Artifact(TagMixin):
     name: str
 
     id: str = field(default_factory=uuid.uuid4)
     description: str = None
     created_at: datetime = field(default_factory=datetime.utcnow)
+    tags: List[str] = field(default_factory=list)
 
     parent_id: str = None

--- a/rubicon_ml/repository/asynchronous/base.py
+++ b/rubicon_ml/repository/asynchronous/base.py
@@ -819,7 +819,9 @@ class AsynchronousBaseRepository(BaseRepository):
 
     @connect
     @invalidate_cache
-    async def add_tags(self, project_name, tags, experiment_id=None, dataframe_id=None):
+    async def add_tags(
+        self, project_name, tags, experiment_id=None, dataframe_id=None, entity_type=None
+    ):
         """Overrides `rubicon.repository.BaseRepository.add_tags
         to asynchronously persist tags to the configured filesystem.
 
@@ -837,14 +839,18 @@ class AsynchronousBaseRepository(BaseRepository):
             The ID of the dataframe to apply the tags
             `tags` to.
         """
-        tag_metadata_root = self._get_tag_metadata_root(project_name, experiment_id, dataframe_id)
+        tag_metadata_root = self._get_tag_metadata_root(
+            project_name, experiment_id, dataframe_id, entity_type
+        )
         tag_metadata_path = f"{tag_metadata_root}/tags_{domain.utils.uuid.uuid4()}.json"
 
         await self._persist_domain({"added_tags": tags}, tag_metadata_path)
 
     @connect
     @invalidate_cache
-    async def remove_tags(self, project_name, tags, experiment_id=None, dataframe_id=None):
+    async def remove_tags(
+        self, project_name, tags, experiment_id=None, dataframe_id=None, entity_type=None
+    ):
         """Overrides `rubicon.repository.BaseRepository.remove_tags`
         to asynchronously delete tags from the configured filesystem.
 
@@ -862,13 +868,15 @@ class AsynchronousBaseRepository(BaseRepository):
             The ID of the dataframe to delete the tags
             `tags` from.
         """
-        tag_metadata_root = self._get_tag_metadata_root(project_name, experiment_id, dataframe_id)
+        tag_metadata_root = self._get_tag_metadata_root(
+            project_name, experiment_id, dataframe_id, entity_type
+        )
         tag_metadata_path = f"{tag_metadata_root}/tags_{domain.utils.uuid.uuid4()}.json"
 
         await self._persist_domain({"removed_tags": tags}, tag_metadata_path)
 
     @connect
-    async def get_tags(self, project_name, experiment_id=None, dataframe_id=None):
+    async def get_tags(self, project_name, experiment_id=None, dataframe_id=None, entity_type=None):
         """Overrides `rubicon.repository.BaseRepository.get_tags` to
         asynchronously retrieve tags from the configured filesystem.
 
@@ -890,7 +898,9 @@ class AsynchronousBaseRepository(BaseRepository):
             value is a list of tag names that have been
             added to or removed from the specified object.
         """
-        tag_metadata_root = self._get_tag_metadata_root(project_name, experiment_id, dataframe_id)
+        tag_metadata_root = self._get_tag_metadata_root(
+            project_name, experiment_id, dataframe_id, entity_type
+        )
 
         all_paths = await self.filesystem._lsdir(tag_metadata_root)
         tag_paths = [p for p in all_paths if "/tags_" in p["name"]]

--- a/rubicon_ml/repository/base.py
+++ b/rubicon_ml/repository/base.py
@@ -916,6 +916,7 @@ class BaseRepository:
     def _get_tag_metadata_root(
         self, project_name, experiment_id=None, entity_id=None, entity_type=None
     ):
+        """Returns the directory to write tags to."""
         get_metadata_root_lookup = {
             "Artifact": self._get_artifact_metadata_root,
             "Dataframe": self._get_dataframe_metadata_root,
@@ -949,9 +950,12 @@ class BaseRepository:
         experiment_id : str, optional
             The ID of the experiment to apply the tags
             `tags` to.
-        dataframe_id : str, optional
-            The ID of the dataframe to apply the tags
+        entity_id : str, optional
+            The ID of the entity to apply the tags
             `tags` to.
+        entity_type : str, optional
+            The name of the entity's type as returned by
+            `entity_cls.__class__.__name__`.
         """
         tag_metadata_root = self._get_tag_metadata_root(
             project_name, experiment_id, entity_id, entity_type
@@ -973,9 +977,12 @@ class BaseRepository:
         experiment_id : str, optional
             The ID of the experiment to delete the tags
             `tags` from.
-        dataframe_id : str, optional
-            The ID of the dataframe to delete the tags
-            `tags` from.
+        entity_id : str, optional
+            The ID of the entity to apply the tags
+            `tags` to.
+        entity_type : str, optional
+            The name of the entity's type as returned by
+            `entity_cls.__class__.__name__`.
         """
         tag_metadata_root = self._get_tag_metadata_root(
             project_name, experiment_id, entity_id, entity_type
@@ -1008,8 +1015,12 @@ class BaseRepository:
             tags from belongs to.
         experiment_id : str, optional
             The ID of the experiment to retrieve tags from.
-        dataframe_id : str, optional
-            The ID of the dataframe to retrieve tags from.
+        entity_id : str, optional
+            The ID of the entity to apply the tags
+            `tags` to.
+        entity_type : str, optional
+            The name of the entity's type as returned by
+            `entity_cls.__class__.__name__`.
 
         Returns
         -------

--- a/rubicon_ml/repository/base.py
+++ b/rubicon_ml/repository/base.py
@@ -921,9 +921,13 @@ class BaseRepository:
             "Dataframe": self._get_dataframe_metadata_root,
             "Experiment": self._get_experiment_metadata_root,
         }
-        get_metadata_root = get_metadata_root_lookup[entity_type]
 
-        if entity_type == "experiment":
+        try:
+            get_metadata_root = get_metadata_root_lookup[entity_type]
+        except KeyError:
+            raise ValueError("`experiment_id` and `entity_id` can not both be `None`.")
+
+        if entity_type == "Experiment":
             experiment_metadata_root = get_metadata_root(project_name)
 
             return f"{experiment_metadata_root}/{experiment_id}"
@@ -931,8 +935,6 @@ class BaseRepository:
             entity_metadata_root = get_metadata_root(project_name, experiment_id)
 
             return f"{entity_metadata_root}/{entity_id}"
-
-        raise ValueError("`experiment_id` and `entity_id` can not both be `None`.")
 
     def add_tags(self, project_name, tags, experiment_id=None, entity_id=None, entity_type=None):
         """Persist tags to the configured filesystem.

--- a/tests/unit/client/test_experiment_client.py
+++ b/tests/unit/client/test_experiment_client.py
@@ -34,7 +34,7 @@ def test_properties(project_client):
 def test_get_identifiers(project_client):
     project = project_client
     experiment = project.log_experiment()
-    project_name, experiment_id = experiment._get_parent_identifiers()
+    project_name, experiment_id = experiment._get_identifiers()
 
     assert project_name == project.name
     assert experiment_id == experiment.id

--- a/tests/unit/client/test_experiment_client.py
+++ b/tests/unit/client/test_experiment_client.py
@@ -31,6 +31,15 @@ def test_properties(project_client):
     assert experiment.project == project
 
 
+def test_get_identifiers(project_client):
+    project = project_client
+    experiment = project.log_experiment()
+    project_name, experiment_id = experiment._get_parent_identifiers()
+
+    assert project_name == project.name
+    assert experiment_id == experiment.id
+
+
 def test_log_metric(project_client):
     project = project_client
     experiment = project.log_experiment(name="exp1")

--- a/tests/unit/client/test_mixin_client.py
+++ b/tests/unit/client/test_mixin_client.py
@@ -333,14 +333,45 @@ def test_get_taggable_experiment_identifiers(project_client):
 
 def test_get_taggable_dataframe_identifiers(project_client, test_dataframe):
     project = project_client
-    df = test_dataframe
-    logged_df = project.log_dataframe(df)
+    experiment = project.log_experiment()
 
-    project_name, experiment_id, dataframe_id = TagMixin._get_taggable_identifiers(logged_df)
+    df = test_dataframe
+    project_df = project.log_dataframe(df)
+    experiment_df = experiment.log_dataframe(df)
+
+    project_name, experiment_id, dataframe_id = TagMixin._get_taggable_identifiers(project_df)
 
     assert project_name == project.name
     assert experiment_id is None
-    assert dataframe_id == logged_df.id
+    assert dataframe_id == project_df.id
+
+    project_name, experiment_id, dataframe_id = TagMixin._get_taggable_identifiers(experiment_df)
+
+    assert project_name == project.name
+    assert experiment_id is experiment.id
+    assert dataframe_id == experiment_df.id
+
+
+def test_get_taggable_artifact_identifiers(project_client):
+    project = project_client
+    experiment = project.log_experiment()
+
+    project_artifact = project.log_artifact(data_bytes=b"test", name="test")
+    experiment_artifact = experiment.log_artifact(data_bytes=b"test", name="test")
+
+    project_name, experiment_id, artifact_id = TagMixin._get_taggable_identifiers(project_artifact)
+
+    assert project_name == project.name
+    assert experiment_id is None
+    assert artifact_id == project_artifact.id
+
+    project_name, experiment_id, artifact_id = TagMixin._get_taggable_identifiers(
+        experiment_artifact
+    )
+
+    assert project_name == project.name
+    assert experiment_id is experiment.id
+    assert artifact_id == experiment_artifact.id
 
 
 def test_add_tags(project_client):

--- a/tests/unit/client/test_mixin_client.py
+++ b/tests/unit/client/test_mixin_client.py
@@ -4,30 +4,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from rubicon_ml.client.mixin import (
-    ArtifactMixin,
-    DataframeMixin,
-    MultiParentMixin,
-    TagMixin,
-)
+from rubicon_ml.client.mixin import ArtifactMixin, DataframeMixin, TagMixin
 from rubicon_ml.exceptions import RubiconException
-
-
-def test_get_project_identifiers(project_client):
-    project = project_client
-    project_name, experiment_id = MultiParentMixin._get_parent_identifiers(project)
-
-    assert project_name == project.name
-    assert experiment_id is None
-
-
-def test_get_experiment_identifiers(project_client):
-    project = project_client
-    experiment = project.log_experiment()
-    project_name, experiment_id = MultiParentMixin._get_parent_identifiers(experiment)
-
-    assert project_name == project.name
-    assert experiment_id == experiment.id
 
 
 # ArtifactMixin

--- a/tests/unit/client/test_project_client.py
+++ b/tests/unit/client/test_project_client.py
@@ -61,7 +61,7 @@ def test_get_commit_hash(project_client):
 
 def test_get_identifiers(project_client):
     project = project_client
-    project_name, experiment_id = project._get_parent_identifiers()
+    project_name, experiment_id = project._get_identifiers()
 
     assert project_name == project.name
     assert experiment_id is None

--- a/tests/unit/client/test_project_client.py
+++ b/tests/unit/client/test_project_client.py
@@ -59,6 +59,14 @@ def test_get_commit_hash(project_client):
         assert mock_run.mock_calls == expected
 
 
+def test_get_identifiers(project_client):
+    project = project_client
+    project_name, experiment_id = project._get_parent_identifiers()
+
+    assert project_name == project.name
+    assert experiment_id is None
+
+
 def test_create_experiment_with_auto_git():
     with mock.patch("subprocess.run") as mock_run:
         mock_run.return_value = MockCompletedProcess(stdout=b"test", returncode=0)

--- a/tests/unit/repository/asynchronous/test_asyn_base_repo.py
+++ b/tests/unit/repository/asynchronous/test_asyn_base_repo.py
@@ -801,7 +801,10 @@ def test_add_tags(asyn_repo_w_mock_filesystem):
     tags = ["x"]
     asyncio.run(
         asyn_repo_w_mock_filesystem.add_tags(
-            experiment.project_name, tags, experiment_id=experiment.id
+            experiment.project_name,
+            tags,
+            experiment_id=experiment.id,
+            entity_type=experiment.__class__.__name__,
         )
     )
 
@@ -818,7 +821,10 @@ def test_remove_tags(asyn_repo_w_mock_filesystem):
     tags = ["x"]
     asyncio.run(
         asyn_repo_w_mock_filesystem.remove_tags(
-            experiment.project_name, tags, experiment_id=experiment.id
+            experiment.project_name,
+            tags,
+            experiment_id=experiment.id,
+            entity_type=experiment.__class__.__name__,
         )
     )
 
@@ -839,7 +845,11 @@ def test_get_tags(asyn_repo_w_mock_filesystem):
     asyn_repo_w_mock_filesystem.filesystem._cat_file.return_value = '{"test":"test"}'
 
     asyncio.run(
-        asyn_repo_w_mock_filesystem.get_tags(experiment.project_name, experiment_id=experiment.id)
+        asyn_repo_w_mock_filesystem.get_tags(
+            experiment.project_name,
+            experiment_id=experiment.id,
+            entity_type=experiment.__class__.__name__,
+        )
     )
 
     filesystem_expected = [call._lsdir(ANY), call._cat_file(ANY)]
@@ -854,7 +864,11 @@ def test_get_tags_with_no_results(asyn_repo_w_mock_filesystem):
     asyn_repo_w_mock_filesystem.filesystem._lsdir.return_value = []
 
     tags = asyncio.run(
-        asyn_repo_w_mock_filesystem.get_tags(experiment.project_name, experiment_id=experiment.id)
+        asyn_repo_w_mock_filesystem.get_tags(
+            experiment.project_name,
+            experiment_id=experiment.id,
+            entity_type=experiment.__class__.__name__,
+        )
     )
 
     filesystem_expected = [call._lsdir(ANY)]

--- a/tests/unit/repository/test_base_repo.py
+++ b/tests/unit/repository/test_base_repo.py
@@ -818,7 +818,9 @@ def test_get_experiment_tags_root(memory_repository):
     repository = memory_repository
     experiment = _create_experiment(repository)
     experiment_tags_root = repository._get_tag_metadata_root(
-        experiment.project_name, experiment_id=experiment.id
+        experiment.project_name,
+        experiment_id=experiment.id,
+        entity_type=experiment.__class__.__name__,
     )
 
     assert (
@@ -831,7 +833,9 @@ def test_get_dataframe_tags_with_project_parent_root(memory_repository):
     repository = memory_repository
     project = _create_project(repository)
     dataframe = _create_pandas_dataframe(repository, project=project)
-    dataframe_tags_root = repository._get_tag_metadata_root(project.name, dataframe_id=dataframe.id)
+    dataframe_tags_root = repository._get_tag_metadata_root(
+        project.name, entity_id=dataframe.id, entity_type=dataframe.__class__.__name__
+    )
 
     assert (
         dataframe_tags_root
@@ -848,7 +852,10 @@ def test_get_dataframe_tags_with_experiment_parent_root(memory_repository):
     repository.create_dataframe(dataframe, dataframe_data, experiment.project_name, experiment.id)
 
     dataframe_tags_root = repository._get_tag_metadata_root(
-        experiment.project_name, experiment_id=experiment.id, dataframe_id=dataframe.id
+        experiment.project_name,
+        experiment_id=experiment.id,
+        entity_id=dataframe.id,
+        entity_type=dataframe.__class__.__name__,
     )
 
     assert (
@@ -865,13 +872,18 @@ def test_get_root_without_experiment_or_dataframe_throws_error(memory_repository
     with pytest.raises(ValueError) as e:
         repository._get_tag_metadata_root(project.name)
 
-    assert "`experiment_id` and `dataframe_id` can not both be `None`" in str(e)
+    assert "`experiment_id` and `entity_id` can not both be `None`" in str(e)
 
 
 def test_add_tags(memory_repository):
     repository = memory_repository
     experiment = _create_experiment(repository)
-    repository.add_tags(experiment.project_name, ["wow"], experiment_id=experiment.id)
+    repository.add_tags(
+        experiment.project_name,
+        ["wow"],
+        experiment_id=experiment.id,
+        entity_type=experiment.__class__.__name__,
+    )
 
     tags_glob = f"{repository.root_dir}/{slugify(experiment.project_name)}/experiments/{experiment.id}/tags_*.json"
     tags_files = repository.filesystem.glob(tags_glob)
@@ -888,7 +900,12 @@ def test_add_tags(memory_repository):
 def test_remove_tags(memory_repository):
     repository = memory_repository
     experiment = _create_experiment(repository, tags=["wow"])
-    repository.remove_tags(experiment.project_name, ["wow"], experiment_id=experiment.id)
+    repository.remove_tags(
+        experiment.project_name,
+        ["wow"],
+        experiment_id=experiment.id,
+        entity_type=experiment.__class__.__name__,
+    )
 
     tags_glob = f"{repository.root_dir}/{slugify(experiment.project_name)}/experiments/{experiment.id}/tags_*.json"
     tags_files = repository.filesystem.glob(tags_glob)
@@ -905,10 +922,24 @@ def test_remove_tags(memory_repository):
 def test_get_tags(memory_repository):
     repository = memory_repository
     experiment = _create_experiment(repository, tags=["wow"])
-    repository.add_tags(experiment.project_name, ["cool"], experiment_id=experiment.id)
-    repository.remove_tags(experiment.project_name, ["wow"], experiment_id=experiment.id)
+    repository.add_tags(
+        experiment.project_name,
+        ["cool"],
+        experiment_id=experiment.id,
+        entity_type=experiment.__class__.__name__,
+    )
+    repository.remove_tags(
+        experiment.project_name,
+        ["wow"],
+        experiment_id=experiment.id,
+        entity_type=experiment.__class__.__name__,
+    )
 
-    tags = repository.get_tags(experiment.project_name, experiment_id=experiment.id)
+    tags = repository.get_tags(
+        experiment.project_name,
+        experiment_id=experiment.id,
+        entity_type=experiment.__class__.__name__,
+    )
 
     assert {"added_tags": ["cool"]} in tags
     assert {"removed_tags": ["wow"]} in tags
@@ -918,6 +949,10 @@ def test_get_tags_with_no_results(memory_repository):
     repository = memory_repository
     experiment = _create_experiment(repository)
 
-    tags = repository.get_tags(experiment.project_name, experiment_id=experiment.id)
+    tags = repository.get_tags(
+        experiment.project_name,
+        experiment_id=experiment.id,
+        entity_type=experiment.__class__.__name__,
+    )
 
     assert tags == []


### PR DESCRIPTION
closes: #244 

---

## What
  * add tagging to artifacts
    * applied the `TagMixin` to the artifact domain object
    * updated client and repo layer to reflect `TagMixin` addition
      * updated `_get_tag_metadata_root` to handle all rubicon objects
  * updated tests

## How to Test
  * run through the quick look examples and validate they work as expected
  * try logging tags to artifacts
 
```python
from rubicon_ml import Rubicon

rubicon = Rubicon(persistence="filesystem", root_dir=".")

# test tagging project artifacts
project = rubicon.get_or_create_project(name="test artifacts")
project.log_artifact(data_bytes=b"bytes", name="name", tags=["tags_a"])

# test tagging experiment artifacts
experiment = project.log_experiment()
experiment.log_artifact(data_bytes=b"bytes", name="name", tags=["tags_b"])
```