### PR TITLE
name cleanup

### DIFF
--- a/rubicon_ml/client/experiment.py
+++ b/rubicon_ml/client/experiment.py
@@ -8,7 +8,7 @@ from rubicon_ml.client import (
     Parameter,
     TagMixin,
 )
-from rubicon_ml.client.utils.tags import filter_entity
+from rubicon_ml.client.utils.tags import filter_children
 
 
 class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
@@ -94,7 +94,7 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
             The metrics previously logged to this experiment.
         """
         metrics = [Metric(m, self) for m in self.repository.get_metrics(self.project.name, self.id)]
-        self._metrics = filter_entity(metrics, tags, qtype, name)
+        self._metrics = filter_children(metrics, tags, qtype, name)
 
         return self._metrics
 

--- a/rubicon_ml/client/mixin.py
+++ b/rubicon_ml/client/mixin.py
@@ -391,17 +391,19 @@ class TagMixin:
 
     def _get_taggable_identifiers(self):
         project_name, experiment_id = self._parent._get_identifiers()
-        entity_id = None
+        entity_identifier = None
 
-        # experiments are not required to return an entity ID - they are the entity
+        # experiments do not return an entity identifier - they are the entity
         if isinstance(self, client.Experiment):
             experiment_id = self.id
+        # dataframes and artifacts are identified by their `id`s
         elif isinstance(self, client.Dataframe) or isinstance(self, client.Artifact):
-            entity_id = self.id
+            entity_identifier = self.id
+        # everything else is identified by its `name`
         else:
-            entity_id = self.name
+            entity_identifier = self.name
 
-        return project_name, experiment_id, entity_id
+        return project_name, experiment_id, entity_identifier
 
     def add_tags(self, tags):
         """Add tags to this client object.
@@ -411,14 +413,14 @@ class TagMixin:
         tags : list of str
             The tag values to add.
         """
-        project_name, experiment_id, entity_id = self._get_taggable_identifiers()
+        project_name, experiment_id, entity_identifier = self._get_taggable_identifiers()
 
         self._domain.add_tags(tags)
         self.repository.add_tags(
             project_name,
             tags,
             experiment_id=experiment_id,
-            entity_id=entity_id,
+            entity_identifier=entity_identifier,
             entity_type=self.__class__.__name__,
         )
 
@@ -430,14 +432,14 @@ class TagMixin:
         tags : list of str
              The tag values to remove.
         """
-        project_name, experiment_id, entity_id = self._get_taggable_identifiers()
+        project_name, experiment_id, entity_identifier = self._get_taggable_identifiers()
 
         self._domain.remove_tags(tags)
         self.repository.remove_tags(
             project_name,
             tags,
             experiment_id=experiment_id,
-            entity_id=entity_id,
+            entity_identifier=entity_identifier,
             entity_type=self.__class__.__name__,
         )
 
@@ -452,11 +454,11 @@ class TagMixin:
     @property
     def tags(self):
         """Get this client object's tags."""
-        project_name, experiment_id, entity_id = self._get_taggable_identifiers()
+        project_name, experiment_id, entity_identifier = self._get_taggable_identifiers()
         tag_data = self.repository.get_tags(
             project_name,
             experiment_id=experiment_id,
-            entity_id=entity_id,
+            entity_identifier=entity_identifier,
             entity_type=self.__class__.__name__,
         )
 

--- a/rubicon_ml/client/mixin.py
+++ b/rubicon_ml/client/mixin.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import fsspec
 
 from rubicon_ml import client, domain
-from rubicon_ml.client.utils.tags import filter_entity
+from rubicon_ml.client.utils.tags import filter_children
 from rubicon_ml.exceptions import RubiconException
 
 
@@ -209,7 +209,7 @@ class ArtifactMixin:
             )
         ]
 
-        self._artifacts = filter_entity(artifacts, tags, qtype, name)
+        self._artifacts = filter_children(artifacts, tags, qtype, name)
 
         return self._artifacts
 
@@ -324,7 +324,7 @@ class DataframeMixin:
             )
         ]
 
-        self._dataframes = filter_entity(dataframes, tags, qtype, name)
+        self._dataframes = filter_children(dataframes, tags, qtype, name)
 
         return self._dataframes
 

--- a/rubicon_ml/client/project.py
+++ b/rubicon_ml/client/project.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from rubicon_ml import domain
 from rubicon_ml.client import ArtifactMixin, Base, DataframeMixin, Experiment
-from rubicon_ml.client.utils.tags import filter_entity
+from rubicon_ml.client.utils.tags import filter_children
 from rubicon_ml.exceptions import RubiconException
 
 
@@ -288,7 +288,7 @@ class Project(Base, ArtifactMixin, DataframeMixin):
             The experiments previously logged to this project.
         """
         experiments = [Experiment(e, self) for e in self.repository.get_experiments(self.name)]
-        self._experiments = filter_entity(experiments, tags, qtype, name)
+        self._experiments = filter_children(experiments, tags, qtype, name)
 
         return self._experiments
 

--- a/rubicon_ml/client/utils/tags.py
+++ b/rubicon_ml/client/utils/tags.py
@@ -22,9 +22,9 @@ def filter_children(children, tags, qtype, name):
     filtered_children = children
 
     if len(tags) > 0:
-        # TODO: what is this?
-        filtered_children = []
-        [filtered_children.append(c) for c in children if has_tag_requirements(c.tags, tags, qtype)]
+        filtered_children = [
+            c for c in filtered_children if has_tag_requirements(c.tags, tags, qtype)
+        ]
     if name is not None:
         filtered_children = [c for c in filtered_children if c.name == name]
 

--- a/rubicon_ml/client/utils/tags.py
+++ b/rubicon_ml/client/utils/tags.py
@@ -1,6 +1,5 @@
 def has_tag_requirements(tags, required_tags, qtype):
-    """
-    Returns True if `tags` meets the requirements based on
+    """Returns True if `tags` meets the requirements based on
     the values of `required_tags` and `qtype`. False otherwise.
     """
     has_tag_requirements = False
@@ -16,16 +15,17 @@ def has_tag_requirements(tags, required_tags, qtype):
     return has_tag_requirements
 
 
-def filter_entity(entity, tags, qtype, name):
-    """Filters the provided experiments by `tags` using
+def filter_children(children, tags, qtype, name):
+    """Filters the provided rubicon objects by `tags` using
     query type `qtype` and by `name`.
     """
-    filtered_entity = entity
+    filtered_children = children
 
     if len(tags) > 0:
-        filtered_entity = []
-        [filtered_entity.append(e) for e in entity if has_tag_requirements(e.tags, tags, qtype)]
+        # TODO: what is this?
+        filtered_children = []
+        [filtered_children.append(c) for c in children if has_tag_requirements(c.tags, tags, qtype)]
     if name is not None:
-        filtered_entity = [e for e in filtered_entity if e.name == name]
+        filtered_children = [c for c in filtered_children if c.name == name]
 
-    return filtered_entity
+    return filtered_children

--- a/rubicon_ml/repository/base.py
+++ b/rubicon_ml/repository/base.py
@@ -914,7 +914,7 @@ class BaseRepository:
     # ---------- Tags ----------
 
     def _get_tag_metadata_root(
-        self, project_name, experiment_id=None, entity_id=None, entity_type=None
+        self, project_name, experiment_id=None, entity_identifier=None, entity_type=None
     ):
         """Returns the directory to write tags to."""
         get_metadata_root_lookup = {
@@ -927,7 +927,7 @@ class BaseRepository:
         try:
             get_metadata_root = get_metadata_root_lookup[entity_type]
         except KeyError:
-            raise ValueError("`experiment_id` and `entity_id` can not both be `None`.")
+            raise ValueError("`experiment_id` and `entity_identifier` can not both be `None`.")
 
         if entity_type == "Experiment":
             experiment_metadata_root = get_metadata_root(project_name)
@@ -936,9 +936,11 @@ class BaseRepository:
         else:
             entity_metadata_root = get_metadata_root(project_name, experiment_id)
 
-            return f"{entity_metadata_root}/{entity_id}"
+            return f"{entity_metadata_root}/{entity_identifier}"
 
-    def add_tags(self, project_name, tags, experiment_id=None, entity_id=None, entity_type=None):
+    def add_tags(
+        self, project_name, tags, experiment_id=None, entity_identifier=None, entity_type=None
+    ):
         """Persist tags to the configured filesystem.
 
         Parameters
@@ -951,21 +953,23 @@ class BaseRepository:
         experiment_id : str, optional
             The ID of the experiment to apply the tags
             `tags` to.
-        entity_id : str, optional
-            The ID of the entity to apply the tags
+        entity_identifier : str, optional
+            The ID or name of the entity to apply the tags
             `tags` to.
         entity_type : str, optional
             The name of the entity's type as returned by
             `entity_cls.__class__.__name__`.
         """
         tag_metadata_root = self._get_tag_metadata_root(
-            project_name, experiment_id, entity_id, entity_type
+            project_name, experiment_id, entity_identifier, entity_type
         )
         tag_metadata_path = f"{tag_metadata_root}/tags_{domain.utils.uuid.uuid4()}.json"
 
         self._persist_domain({"added_tags": tags}, tag_metadata_path)
 
-    def remove_tags(self, project_name, tags, experiment_id=None, entity_id=None, entity_type=None):
+    def remove_tags(
+        self, project_name, tags, experiment_id=None, entity_identifier=None, entity_type=None
+    ):
         """Delete tags from the configured filesystem.
 
         Parameters
@@ -978,15 +982,15 @@ class BaseRepository:
         experiment_id : str, optional
             The ID of the experiment to delete the tags
             `tags` from.
-        entity_id : str, optional
-            The ID of the entity to apply the tags
+        entity_identifier : str, optional
+            The ID or name of the entity to apply the tags
             `tags` to.
         entity_type : str, optional
             The name of the entity's type as returned by
             `entity_cls.__class__.__name__`.
         """
         tag_metadata_root = self._get_tag_metadata_root(
-            project_name, experiment_id, entity_id, entity_type
+            project_name, experiment_id, entity_identifier, entity_type
         )
         tag_metadata_path = f"{tag_metadata_root}/tags_{domain.utils.uuid.uuid4()}.json"
 
@@ -1006,7 +1010,7 @@ class BaseRepository:
 
         return tag_paths_with_timestamps
 
-    def get_tags(self, project_name, experiment_id=None, entity_id=None, entity_type=None):
+    def get_tags(self, project_name, experiment_id=None, entity_identifier=None, entity_type=None):
         """Retrieve tags from the configured filesystem.
 
         Parameters
@@ -1016,8 +1020,8 @@ class BaseRepository:
             tags from belongs to.
         experiment_id : str, optional
             The ID of the experiment to retrieve tags from.
-        entity_id : str, optional
-            The ID of the entity to apply the tags
+        entity_identifier : str, optional
+            The ID or name of the entity to apply the tags
             `tags` to.
         entity_type : str, optional
             The name of the entity's type as returned by
@@ -1032,7 +1036,7 @@ class BaseRepository:
             added to or removed from the specified object.
         """
         tag_metadata_root = self._get_tag_metadata_root(
-            project_name, experiment_id, entity_id, entity_type
+            project_name, experiment_id, entity_identifier, entity_type
         )
         tag_metadata_glob = f"{tag_metadata_root}/tags_*.json"
 

--- a/tests/unit/repository/test_base_repo.py
+++ b/tests/unit/repository/test_base_repo.py
@@ -834,7 +834,7 @@ def test_get_dataframe_tags_with_project_parent_root(memory_repository):
     project = _create_project(repository)
     dataframe = _create_pandas_dataframe(repository, project=project)
     dataframe_tags_root = repository._get_tag_metadata_root(
-        project.name, entity_id=dataframe.id, entity_type=dataframe.__class__.__name__
+        project.name, entity_identifier=dataframe.id, entity_type=dataframe.__class__.__name__
     )
 
     assert (
@@ -854,7 +854,7 @@ def test_get_dataframe_tags_with_experiment_parent_root(memory_repository):
     dataframe_tags_root = repository._get_tag_metadata_root(
         experiment.project_name,
         experiment_id=experiment.id,
-        entity_id=dataframe.id,
+        entity_identifier=dataframe.id,
         entity_type=dataframe.__class__.__name__,
     )
 
@@ -872,7 +872,7 @@ def test_get_root_without_experiment_or_dataframe_throws_error(memory_repository
     with pytest.raises(ValueError) as e:
         repository._get_tag_metadata_root(project.name)
 
-    assert "`experiment_id` and `entity_id` can not both be `None`" in str(e)
+    assert "`experiment_id` and `entity_identifier` can not both be `None`" in str(e)
 
 
 def test_add_tags(memory_repository):


### PR DESCRIPTION
## What
  * cleaning up/standardizing some naming after the last few tagging stories
    * `filter_entity` -> `filter_children`
    * this ones pretty trivial, but `entity_id` -> `entity_identifier` just to make it clear that the "identifier" can be an id or a name

## How to Test
  * `python -m pytest`
