### PR TITLE
272 parameter tagging

### DIFF
--- a/rubicon_ml/client/asynchronous/experiment.py
+++ b/rubicon_ml/client/asynchronous/experiment.py
@@ -90,7 +90,7 @@ class Experiment(ArtifactMixin, DataframeMixin, TagMixin, SyncExperiment):
         parameter = domain.Parameter(name, value=value, description=description)
         await self.repository.create_parameter(parameter, self.project.name, self.id)
 
-        return Parameter(parameter, self._config)
+        return Parameter(parameter, self)
 
     async def parameters(self):
         """Overrides `rubicon.client.Experiment.parameters` to
@@ -102,7 +102,7 @@ class Experiment(ArtifactMixin, DataframeMixin, TagMixin, SyncExperiment):
             The parameters previously logged to this experiment.
         """
         self._parameters = [
-            Parameter(p, self._config)
+            Parameter(p, self)
             for p in await self.repository.get_parameters(self.project.name, self.id)
         ]
 

--- a/rubicon_ml/client/experiment.py
+++ b/rubicon_ml/client/experiment.py
@@ -217,7 +217,7 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
             The parameter's description. Use to provide
             additional context.
         tags : list of str, optional
-            Values to tag the experiment with. Use tags to organize and
+            Values to tag the parameter with. Use tags to organize and
             filter your parameters.
 
         Returns

--- a/rubicon_ml/client/parameter.py
+++ b/rubicon_ml/client/parameter.py
@@ -24,7 +24,6 @@ class Parameter(Base, TagMixin):
 
     def __init__(self, domain, parent):
         super().__init__(domain, parent._config)
-        self.data = None
         self._parent = parent
 
     @property

--- a/rubicon_ml/client/parameter.py
+++ b/rubicon_ml/client/parameter.py
@@ -1,7 +1,7 @@
-from rubicon_ml.client import Base
+from rubicon_ml.client import Base, TagMixin
 
 
-class Parameter(Base):
+class Parameter(Base, TagMixin):
     """A client parameter.
 
     A `parameter` is an input to an `experiment` (model run)
@@ -18,12 +18,14 @@ class Parameter(Base):
     ----------
     domain : rubicon.domain.Parameter
         The parameter domain model.
-    config : rubicon.client.Config
-        The config, which specifies the underlying repository.
+    parent : rubicon.client.Experiment
+        The experiment that the metric is logged to.
     """
 
-    def __init__(self, domain, config=None):
-        super().__init__(domain, config)
+    def __init__(self, domain, parent):
+        super().__init__(domain, parent._config)
+        self.data = None
+        self._parent = parent
 
     @property
     def id(self):
@@ -49,3 +51,8 @@ class Parameter(Base):
     def created_at(self):
         """Get the time the parameter was created."""
         return self._domain.created_at
+
+    @property
+    def parent(self):
+        """Get the parameter's parent client object."""
+        return self._parent

--- a/rubicon_ml/client/parameter.py
+++ b/rubicon_ml/client/parameter.py
@@ -19,7 +19,7 @@ class Parameter(Base, TagMixin):
     domain : rubicon.domain.Parameter
         The parameter domain model.
     parent : rubicon.client.Experiment
-        The experiment that the metric is logged to.
+        The experiment that the parameter is logged to.
     """
 
     def __init__(self, domain, parent):

--- a/rubicon_ml/domain/parameter.py
+++ b/rubicon_ml/domain/parameter.py
@@ -1,14 +1,17 @@
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import List
 
+from rubicon_ml.domain.mixin import TagMixin
 from rubicon_ml.domain.utils import uuid
 
 
 @dataclass
-class Parameter:
+class Parameter(TagMixin):
     name: str
 
     id: str = field(default_factory=uuid.uuid4)
     value: object = None
     description: str = None
+    tags: List[str] = field(default_factory=list)
     created_at: datetime = field(default_factory=datetime.utcnow)

--- a/rubicon_ml/repository/base.py
+++ b/rubicon_ml/repository/base.py
@@ -922,11 +922,8 @@ class BaseRepository:
             "Dataframe": self._get_dataframe_metadata_root,
             "Experiment": self._get_experiment_metadata_root,
             "Metric": self._get_metric_metadata_root,
-<<<<<<< HEAD
             "Feature": self._get_feature_metadata_root,
-=======
             "Parameter": self._get_parameter_metadata_root,
->>>>>>> 31aedcf (updated code to implement parameter tagging)
         }
 
         try:

--- a/rubicon_ml/repository/base.py
+++ b/rubicon_ml/repository/base.py
@@ -922,7 +922,11 @@ class BaseRepository:
             "Dataframe": self._get_dataframe_metadata_root,
             "Experiment": self._get_experiment_metadata_root,
             "Metric": self._get_metric_metadata_root,
+<<<<<<< HEAD
             "Feature": self._get_feature_metadata_root,
+=======
+            "Parameter": self._get_parameter_metadata_root,
+>>>>>>> 31aedcf (updated code to implement parameter tagging)
         }
 
         try:

--- a/rubicon_ml/repository/base.py
+++ b/rubicon_ml/repository/base.py
@@ -939,7 +939,7 @@ class BaseRepository:
             entity_metadata_root = get_metadata_root(project_name, experiment_id)
 
             # We want to slugify the names of Metrics, Features, and Parameters- not Artifacts, Dataframes, or Experiments
-            if entity_type == "Metric" or entity_type == "Feature" or entity_type == "Parameter":
+            if entity_type in ["Metric", "Feature", "Parameter"]:
                 entity_identifier = slugify(entity_identifier)
             return f"{entity_metadata_root}/{entity_identifier}"
 

--- a/rubicon_ml/repository/base.py
+++ b/rubicon_ml/repository/base.py
@@ -938,6 +938,9 @@ class BaseRepository:
         else:
             entity_metadata_root = get_metadata_root(project_name, experiment_id)
 
+            # We want to slugify the names of Metrics, Features, and Parameters- not Artifacts, Dataframes, or Experiments
+            if entity_type == "Metric" or entity_type == "Feature" or entity_type == "Parameter":
+                entity_identifier = slugify(entity_identifier)
             return f"{entity_metadata_root}/{entity_identifier}"
 
     def add_tags(

--- a/tests/unit/client/test_experiment_client.py
+++ b/tests/unit/client/test_experiment_client.py
@@ -224,3 +224,32 @@ def test_get_parameter_by_id(project_client):
 
     parameter = experiment.parameter(id=parameter_id).name
     assert parameter == "n_estimators"
+
+
+def test_parameters_tagged_and(project_client):
+    project = project_client
+    experiment = project.log_experiment(name="exp1")
+
+    parameter = experiment.log_parameter(name="param_1", tags=["x", "y"])
+    experiment.log_parameter(name="param_2", tags=["x"])
+    experiment.log_parameter(name="param_3", tags=["y"])
+
+    parameters = experiment.parameters(tags=["x", "y"], qtype="and")
+
+    assert len(parameters) == 1
+    assert parameter.id in [d.id for d in parameters]
+
+
+def test_parameters_tagged_or(project_client):
+    project = project_client
+    experiment = project.log_experiment(name="exp1")
+
+    param_a = experiment.log_parameter(name="param_a", tags=["x"])
+    param_b = experiment.log_parameter(name="param_b", tags=["y"])
+    experiment.log_parameter(name="param_c", tags=["z"])
+
+    parameters = experiment.parameters(tags=["x", "y"], qtype="or")
+
+    assert len(parameters) == 2
+    assert param_a.id in [d.id for d in parameters]
+    assert param_b.id in [d.id for d in parameters]

--- a/tests/unit/client/test_parameter_client.py
+++ b/tests/unit/client/test_parameter_client.py
@@ -1,13 +1,16 @@
+from unittest.mock import MagicMock
+
 from rubicon_ml import domain
 from rubicon_ml.client import Parameter
 
 
 def test_properties():
     domain_parameter = domain.Parameter("name", value="value", description="description")
-    parameter = Parameter(domain_parameter)
+    parameter = Parameter(domain_parameter, MagicMock())
 
     assert parameter.id == domain_parameter.id
     assert parameter.name == domain_parameter.name
     assert parameter.value == domain_parameter.value
     assert parameter.description == domain_parameter.description
     assert parameter.created_at == domain_parameter.created_at
+    assert hasattr(parameter, "parent")


### PR DESCRIPTION
closes: #272

---

## What
  * Adds tagging functionality to parameters in Rubicon experiments
       *  Extends parameter domain with `TagMixin` class
       *  Updates parameter functions in `client/experiment.py` for tagging functionality
       *  Adds `parents` attribute to parameter client

## How to Test
  * Run unit tests with pytest
  * Open quick-look jupyter notebook to test functionality

> ```
> from rubicon_ml import Rubicon
> 
> rubicon = Rubicon(
>     persistence="filesystem",
>     root_dir="./rubicon-root",
>     auto_git_enabled=True,
> )
> project = rubicon.get_or_create_project(name="classifying penguins")
> experiment = project.log_experiment()
> 
> param_a = experiment.log_parameter(name="param_a")
> param_b = experiment.log_parameter(name="param_b")
> param_c = experiment.log_parameter(name="param_c")
> 
> param_a.add_tags(["tag1", "tag2"])
> param_b.add_tags(["tag1", "tag3"])
> param_c.add_tags(["tag2"])
> 
> param_a.tags
> param_b.tags
> 
> param_b.remove_tags(["tag3"])
> param_b.tags
> 
> parameters_list = experiment.parameters(tags=["tag1"])
> parameters_list
> ```