### PR TITLE
fix binder examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/rubicon-ml.svg)](https://anaconda.org/conda-forge/rubicon-ml)
 [![PyPi Version](https://img.shields.io/pypi/v/rubicon_ml.svg)](https://pypi.org/project/rubicon-ml/)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/capitalone/rubicon-ml/main?filepath=binder%2Fwelcome.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/capitalone/rubicon-ml/main?labpath=binder%2Fwelcome.ipynb)
+
 
 ## Purpose
 
@@ -54,7 +55,7 @@ context necessary for a complete model review and approval.
 
 ## Use
 
-Check out the [interactive notebooks in this Binder](https://mybinder.org/v2/gh/capitalone/rubicon-ml/main?filepath=binder%2Fwelcome.ipynb)
+Check out the [interactive notebooks in this Binder](https://mybinder.org/v2/gh/capitalone/rubicon-ml/main?labpath=binder%2Fwelcome.ipynb)
 to try `rubicon_ml` for yourself.
 
 Here's a simple example:

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,5 +5,4 @@ dependencies:
   - python>=3.8
   - pip
 
-  - jupyter-server-proxy
   - rubicon-ml

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,4 +5,5 @@ dependencies:
   - python>=3.8
   - pip
 
+  - jupyter-server-proxy
   - rubicon-ml

--- a/binder/welcome.ipynb
+++ b/binder/welcome.ipynb
@@ -58,7 +58,7 @@
     "requests_pathname_prefix = f\"{os.environ['JUPYTERHUB_SERVICE_PREFIX']}proxy/{port}/\"\n",
     "\n",
     "dash_kwargs = {\"requests_pathname_prefix\": requests_pathname_prefix}\n",
-    "run_server_kwargs = {\"proxy\": f\"http://127.0.0.1:{port}::{default_server_url}\"}\n",
+    "run_server_kwargs = {\"proxy\": f\"http://127.0.0.1:{port}::{default_server_url}\", \"port\": port}\n",
     "\n",
     "rubicon = Rubicon(persistence=\"filesystem\", root_dir=f\"{os.getcwd()}/rubicon-root\")\n",
     "project = rubicon.get_project(name=\"Classifying Penguins\")\n",

--- a/binder/welcome.ipynb
+++ b/binder/welcome.ipynb
@@ -31,13 +31,17 @@
     "different types of models were used to classify species of penguins by\n",
     "some physical characteristics. During each model run, `rubicon_ml` was used to log the results.\n",
     "\n",
-    "The `rubicon_ml` logs from that project have been copied locally into this Binder session. In a more realistic use case, you may be reading shared `rubicon_ml` logs from S3.\n",
+    "The `rubicon_ml` logs from that project have been copied locally into this Binder session. In \n",
+    "a more realistic use case, you may be reading shared `rubicon_ml` logs from S3.\n",
     "\n",
     "There are a number of questions you'll be able to answer by using the experiment table below:\n",
     "* What were the input parameters and output metrics of each model run?\n",
     "* What type of model did each run use?\n",
     "* Where is the source code that was used to generate each model run's logs?\n",
-    "* Which model and input parameters produced the best results?"
+    "* Which model and input parameters produced the best results?\n",
+    "\n",
+    "**Note: `default_server_url` should match the root of the URL currently in your address \n",
+    "bar - change as necessary.**"
    ]
   },
   {
@@ -52,7 +56,9 @@
     "from rubicon_ml import Rubicon\n",
     "from rubicon_ml.viz import ExperimentsTable\n",
     "\n",
-    "default_server_url = \"https://hub-binder.mybinder.ovh\"\n",
+    "\n",
+    "default_server_url = \"https://hub.gke2.mybinder.org/\"\n",
+    "# default_server_url = \"https://hub-binder.mybinder.ovh\"\n",
     "port = 8050\n",
     "\n",
     "requests_pathname_prefix = f\"{os.environ['JUPYTERHUB_SERVICE_PREFIX']}proxy/{port}/\"\n",

--- a/binder/welcome.ipynb
+++ b/binder/welcome.ipynb
@@ -11,9 +11,9 @@
     "\n",
     "# Welcome to the `rubicon_ml` examples!\n",
     "\n",
-    "Here you'll find some interactive examples so you can try out `rubicon_ml` for yourself\n",
-    "without any setup required. If you'd like to learn more about `rubicon_ml` before getting\n",
-    "started, check out the [documentation on GitHub](https://capitalone.github.io/rubicon-ml/)."
+    "Try out `rubicon_ml` for yourself without any setup required! If you'd like to learn more about \n",
+    "`rubicon_ml` before getting started, check out the \n",
+    "[documentation on GitHub](https://capitalone.github.io/rubicon-ml/)."
    ]
   },
   {
@@ -23,7 +23,8 @@
    "source": [
     "## Exploring an existing `rubicon_ml` project\n",
     "\n",
-    "Below we'll explore a `rubicon_ml` project using the dashboard to inspect and analyze some previous model runs.\n",
+    "Below we'll explore an existing `rubicon_ml` project using the built-in visualization module to \n",
+    "inspect and analyze some previously trained models.\n",
     "\n",
     "[This GitHub repository](https://github.com/ryanSoley/experimenting-with-rubicon) contains\n",
     "a simple classification model in `my_model/my_model.py`. Over three commits, three\n",
@@ -32,10 +33,7 @@
     "\n",
     "The `rubicon_ml` logs from that project have been copied locally into this Binder session. In a more realistic use case, you may be reading shared `rubicon_ml` logs from S3.\n",
     "\n",
-    "Launch the dashboard by running the cell below! And once the dashboard renders, select the **Classifying\n",
-    "Penguins** project from the sidebar. \n",
-    "\n",
-    "By using the dashboard, there are a number of questions you'll be able to answer:\n",
+    "There are a number of questions you'll be able to answer by using the experiment table below:\n",
     "* What were the input parameters and output metrics of each model run?\n",
     "* What type of model did each run use?\n",
     "* Where is the source code that was used to generate each model run's logs?\n",
@@ -50,22 +48,23 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "from rubicon_ml.ui.dashboard import Dashboard\n",
     "\n",
+    "from rubicon_ml import Rubicon\n",
+    "from rubicon_ml.viz import ExperimentsTable\n",
+    "\n",
+    "default_server_url = \"https://hub-binder.mybinder.ovh\"\n",
     "port = 8050\n",
-    "default_server_url = \"https://hub.gke2.mybinder.org/\"\n",
-    "proxy = f\"http://127.0.0.1:{port}::https://hub.gke2.mybinder.org/\"\n",
-    "requests_pathname_prefix = f\"{os.environ['JUPYTERHUB_SERVICE_PREFIX']}/proxy/{port}/\"\n",
     "\n",
-    "dash_options = {\n",
-    "   \"requests_pathname_prefix\": requests_pathname_prefix\n",
-    "}\n",
+    "requests_pathname_prefix = f\"{os.environ['JUPYTERHUB_SERVICE_PREFIX']}proxy/{port}/\"\n",
     "\n",
-    "Dashboard(\n",
-    "   persistence=\"filesystem\",\n",
-    "   root_dir=f\"{os.getcwd()}/rubicon-root\",\n",
-    "   dash_options=dash_options\n",
-    ").run_server_inline(port=port, proxy=proxy)"
+    "dash_kwargs = {\"requests_pathname_prefix\": requests_pathname_prefix}\n",
+    "run_server_kwargs = {\"proxy\": f\"http://127.0.0.1:{port}::{default_server_url}\"}\n",
+    "\n",
+    "rubicon = Rubicon(persistence=\"filesystem\", root_dir=f\"{os.getcwd()}/rubicon-root\")\n",
+    "project = rubicon.get_project(name=\"Classifying Penguins\")\n",
+    "\n",
+    "experiments_table = ExperimentsTable(experiments=project.experiments())\n",
+    "experiments_table.show(dash_kwargs=dash_kwargs, run_server_kwargs=run_server_kwargs)"
    ]
   },
   {
@@ -75,14 +74,13 @@
    "source": [
     "## Running Other `rubicon_ml` Examples\n",
     "\n",
-    "You can also run the [**Quick Look**](https://capitalone.github.io/rubicon-ml/quick-look.html)\n",
-    "and the examples found in the [**Examples**](https://capitalone.github.io/rubicon-ml/examples.html)\n",
-    "and [**Integrations**](https://capitalone.github.io/rubicon-ml/integrations.html)\n",
-    "sections of our documentation in this session! These examples will show how to log\n",
-    "your own projects and experiments. Run the cell below to generate the links to these\n",
-    "examples for the current Binder session.\n",
+    "You can run any of the examples from the `rubicon_ml` docs in this Binder session! These examples \n",
+    "will show how to log your own projects and experiments, share and visualize them. Run the cell below \n",
+    "to generate the links to these examples for the current Binder session.\n",
     "\n",
-    "**Note:** This cell won't work if you haven't run the rest of this notebook."
+    "**Note: The examples in the \"Visualizations\" section will need to be manually updated to provide \n",
+    "the `show` and `serve` methods the same `dash_kwargs` and `run_server_kwargs` arguments as the cell \n",
+    "above.**"
    ]
   },
   {
@@ -96,9 +94,10 @@
     "    default_server_url + requests_pathname_prefix\n",
     "))))\n",
     "\n",
-    "print(f\"Quick Look: {session_base_url}/tree/notebooks/quick-look.ipynb\")\n",
-    "print(f\"Examples: {session_base_url}/tree/notebooks/logging-examples\")\n",
-    "print(f\"Integrations: {session_base_url}/tree/notebooks/integrations\")"
+    "print(f\"Quick Look: \\t{session_base_url}/tree/notebooks/quick-look\")\n",
+    "print(f\"Examples: \\t{session_base_url}/tree/notebooks/logging-examples\")\n",
+    "print(f\"Integrations: \\t{session_base_url}/tree/notebooks/integrations\")\n",
+    "print(f\"Visualizations: {session_base_url}/tree/notebooks/viz\")"
    ]
   }
  ],
@@ -118,7 +117,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,7 +63,7 @@ nbsphinx_prolog = """
 
 .. |binder_link| raw:: html
 
-   <a href="https://mybinder.org/v2/gh/capitalone/rubicon-ml/main?filepath=notebooks/{{ env.doc2path(env.docname, base=None) }}" target="_blank">run it yourself on Binder</a>
+   <a href="https://mybinder.org/v2/gh/capitalone/rubicon-ml/main?labpath=notebooks/{{ env.doc2path(env.docname, base=None) }}" target="_blank">run it yourself on Binder</a>
 """
 
 autodoc_default_flags = ["members", "inherited-members"]


### PR DESCRIPTION
## What
  * updates binder welcome notebooks
    * leverage new `viz` module over deprecated `ui` module
  * `filepath` -> `labpath` to get links working again

## How to Test
  * https://mybinder.org/v2/gh/capitalone/rubicon-ml/binder-fix?labpath=binder%2Fwelcome.ipynb
    * validate that the landing page notebook works
    * validate that the links to the other notebooks are accessible
      * the other notebooks don't need to work perfectly rn
