### PR TITLE
remove hard `dask` requirement

### DIFF
--- a/docs/docs-environment.yml
+++ b/docs/docs-environment.yml
@@ -19,7 +19,6 @@ dependencies:
   # so local pip install doesn't
   - dash<=2.6.2,>=2.0.0
   - dash-bootstrap-components<=1.2.1,>=1.0.0
-  - dask[dataframe]<=2022.9.2,>=2.12.0
   - fsspec<=2022.8.2,>=2021.4.0
   - intake[dataframe]<=0.6.6,>=0.5.2
   - numpy<=1.23.4,>=1.22.0

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,6 @@ dependencies:
   - pip
 
   - click<=8.1.3,>=7.1
-  - dask[dataframe]<=2022.9.2,>=2.12.0
   - fsspec<=2022.8.2,>=2021.4.0
   - intake[dataframe]<=0.6.6,>=0.5.2
   - numpy<=1.23.4,>=1.22.0
@@ -25,6 +24,7 @@ dependencies:
 
   # for testing
   - black
+  - dask
   - flake8
   - ipykernel
   - isort

--- a/notebooks/logging-examples/logging-concurrently.ipynb
+++ b/notebooks/logging-examples/logging-concurrently.ipynb
@@ -607,7 +607,7 @@
     }
    ],
    "source": [
-    "ddf = rubicon.get_project_as_dask_df(\"Concurrent Experiments\")\n",
+    "ddf = rubicon.get_project_as_df(\"Concurrent Experiments\", df_type=\"dask\")\n",
     "ddf.compute()"
    ]
   }

--- a/rubicon_ml/client/dataframe.py
+++ b/rubicon_ml/client/dataframe.py
@@ -36,8 +36,8 @@ class Dataframe(Base, TagMixin):
         Parameters
         ----------
         df_type : str, optional
-            The type of dataframe. Can be either `pandas` or `dask`.
-            Defaults to 'pandas'.
+            The type of dataframe to return. Valid options include
+            ["dask", "pandas"]. Defaults to "pandas".
         """
         project_name, experiment_id = self.parent._get_identifiers()
 

--- a/rubicon_ml/client/project.py
+++ b/rubicon_ml/client/project.py
@@ -110,20 +110,34 @@ class Project(Base, ArtifactMixin, DataframeMixin):
         return grouped_experiments
 
     def to_dask_df(self, group_by=None):
-        """Loads the project's data into dask dataframe(s) sorted by `created_at`.
-        This includes the experiment details along with parameters and metrics.
+        """For backwards compatibility."""
+        warnings.warn(
+            "`to_dask_df` is deprecated and will be removed in a future release. "
+            "use `to_df(df_type='dask') instead.",
+            DeprecationWarning,
+        )
+
+        return self.to_df(df_type="dask", group_by=group_by)
+
+    def to_df(self, df_type="pandas", group_by=None):
+        """Loads the project's data into dask or pandas dataframe(s) sorted by
+        `created_at`. This includes the experiment details along with parameters
+        and metrics.
 
         Parameters
         ----------
+        df_type : str, optional
+            The type of dataframe to return. Valid options include
+            ["dask", "pandas"]. Defaults to "pandas".
         group_by : str or None, optional
             How to group the project's experiments in the returned
             dataframe(s). Valid options include ["commit_hash"].
 
         Returns
         -------
-        dask.DataFrame or list of dask.DataFrame
-            If `group_by` is `None`, a dask dataframe holding the project's
-            data. Otherwise a list of dask dataframes holding the project's
+        pandas.DataFrame or list of pandas.DataFrame or dask.DataFrame or list of dask.DataFrame
+            If `group_by` is `None`, a dask or pandas dataframe holding the project's
+            data. Otherwise a list of dask or pandas dataframes holding the project's
             data grouped by `group_by`.
         """
         DEFAULT_COLUMNS = [
@@ -170,9 +184,12 @@ class Project(Base, ArtifactMixin, DataframeMixin):
 
             columns = DEFAULT_COLUMNS + list(parameter_names) + list(metric_names)
             df = pd.DataFrame.from_records(experiment_records, columns=columns)
-
             df = df.sort_values(by=["created_at"], ascending=False).reset_index(drop=True)
-            experiment_dfs[group] = dd.from_pandas(df, npartitions=1)
+
+            if df_type == "dask":
+                df = dd.from_pandas(df, npartitions=1)
+
+            experiment_dfs[group] = df
 
         return experiment_dfs if group_by is not None else list(experiment_dfs.values())[0]
 

--- a/rubicon_ml/client/project.py
+++ b/rubicon_ml/client/project.py
@@ -110,7 +110,7 @@ class Project(Base, ArtifactMixin, DataframeMixin):
         return grouped_experiments
 
     def to_dask_df(self, group_by=None):
-        """For backwards compatibility."""
+        """DEPRECATED: Available for backwards compatibility."""
         warnings.warn(
             "`to_dask_df` is deprecated and will be removed in a future release. "
             "use `to_df(df_type='dask') instead.",

--- a/rubicon_ml/client/rubicon.py
+++ b/rubicon_ml/client/rubicon.py
@@ -1,4 +1,5 @@
 import subprocess
+import warnings
 
 from rubicon_ml import domain
 from rubicon_ml.client import Config, Project
@@ -124,26 +125,39 @@ class Rubicon:
         return project
 
     def get_project_as_dask_df(self, name, group_by=None):
-        """Get a dask dataframe representation of a project.
+        """For backwards compatibility."""
+        warnings.warn(
+            "`get_project_as_dask_df` is deprecated and will be removed in a future "
+            "release. use `get_project_as_df('name', df_type='dask') instead.",
+            DeprecationWarning,
+        )
+
+        return self.get_project_as_df(name, df_type="dask", group_by=group_by)
+
+    def get_project_as_df(self, name, df_type="pandas", group_by=None):
+        """Get a dask or pandas dataframe representation of a project.
 
         Parameters
         ----------
         name : str
             The name of the project to get.
+        df_type : str, optional
+            The type of dataframe to return. Valid options include
+            ["dask", "pandas"]. Defaults to "pandas".
         group_by : str or None, optional
             How to group the project's experiments in the returned
             DataFrame(s). Valid options include ["commit_hash"].
 
         Returns
         -------
-        dask.DataFrame or list of dask.DataFrame
-            If `group_by` is `None`, a dask dataframe holding the project's
-            data. Otherwise a list of dask dataframes holding the project's
+        pandas.DataFrame or list of pandas.DataFrame or dask.DataFrame or list of dask.DataFrame
+            If `group_by` is `None`, a dask or pandas dataframe holding the project's
+            data. Otherwise a list of dask or pandas dataframes holding the project's
             data grouped by `group_by`.
         """
         project = self.get_project(name)
 
-        return project.to_dask_df(group_by=None)
+        return project.to_dask_df(df_type=df_type, group_by=None)
 
     def get_or_create_project(self, name, **kwargs):
         """Get or create a project.

--- a/rubicon_ml/client/rubicon.py
+++ b/rubicon_ml/client/rubicon.py
@@ -157,7 +157,7 @@ class Rubicon:
         """
         project = self.get_project(name)
 
-        return project.to_dask_df(df_type=df_type, group_by=None)
+        return project.to_df(df_type=df_type, group_by=None)
 
     def get_or_create_project(self, name, **kwargs):
         """Get or create a project.

--- a/rubicon_ml/client/rubicon.py
+++ b/rubicon_ml/client/rubicon.py
@@ -125,7 +125,7 @@ class Rubicon:
         return project
 
     def get_project_as_dask_df(self, name, group_by=None):
-        """For backwards compatibility."""
+        """DEPRECATED: Available for backwards compatibility."""
         warnings.warn(
             "`get_project_as_dask_df` is deprecated and will be removed in a future "
             "release. use `get_project_as_df('name', df_type='dask') instead.",

--- a/rubicon_ml/repository/base.py
+++ b/rubicon_ml/repository/base.py
@@ -432,7 +432,7 @@ class BaseRepository:
         df = None
         acceptable_types = ["pandas", "dask"]
         if df_type not in acceptable_types:
-            raise RubiconException(f"`df_type` must be one of {acceptable_types}")
+            raise ValueError(f"`df_type` must be one of {acceptable_types}")
 
         if df_type == "pandas":
             path = f"{path}/data.parquet"

--- a/rubicon_ml/repository/base.py
+++ b/rubicon_ml/repository/base.py
@@ -3,7 +3,6 @@ import warnings
 
 import fsspec
 import pandas as pd
-from dask import dataframe as dd
 
 from rubicon_ml import domain
 from rubicon_ml.exceptions import RubiconException
@@ -439,6 +438,15 @@ class BaseRepository:
             path = f"{path}/data.parquet"
             df = pd.read_parquet(path, engine="pyarrow")
         else:
+            try:
+                from dask import dataframe as dd
+            except ImportError:
+                raise RubiconException(
+                    "`rubicon_ml` requires `dask` to be installed in the current environment "
+                    "to read dataframes with `df_type`='dask'. `pip install dask[dataframe]` "
+                    "or `conda install dask` to continue."
+                )
+
             df = dd.read_parquet(path, engine="pyarrow")
 
         return df

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ include_package_data = True
 packages = find:
 install_requires = 
 	click<=8.1.3,>=7.1
-	dask[dataframe]<=2022.9.2,>=2.12.0
 	fsspec<=2022.8.2,>=2021.4.0
 	intake[dataframe]<=0.6.6,>=0.5.2
 	numpy<=1.23.4,>=1.22.0
@@ -101,6 +100,7 @@ deps =
 	shap
 	palmerpenguins
 conda_install = 
+	dask
 	jupyterlab
 	nodejs
 	nbconvert
@@ -114,7 +114,6 @@ upgrade =
 	click
 	dash
 	dash-bootstrap-components
-	dask[dataframe]
 	fsspec
 	intake[dataframe]
 	numpy

--- a/tests/unit/client/test_rubicon_client.py
+++ b/tests/unit/client/test_rubicon_client.py
@@ -2,6 +2,7 @@ import subprocess
 from unittest import mock
 
 import dask.dataframe as dd
+import pandas as pd
 import pytest
 
 from rubicon_ml import client, domain
@@ -169,6 +170,13 @@ def test_sync_from_local_error(mock_get_project, mock_run):
 
 def test_get_project_as_dask_df(rubicon_and_project_client_with_experiments):
     rubicon, project = rubicon_and_project_client_with_experiments
-    ddf = rubicon.get_project_as_dask_df(name="Test Project")
+    ddf = rubicon.get_project_as_df(name="Test Project", df_type="dask")
 
     assert isinstance(ddf, dd.core.DataFrame)
+
+
+def test_get_project_as_pandas_df(rubicon_and_project_client_with_experiments):
+    rubicon, project = rubicon_and_project_client_with_experiments
+    ddf = rubicon.get_project_as_df(name="Test Project", df_type="pandas")
+
+    assert isinstance(ddf, pd.DataFrame)


### PR DESCRIPTION
## What
  * rubicon-ml currently has a hard dask requirement defined in its setup.cfg
    * this is so users can seamlessly log both `dask` and `pandas` dataframes to rubicon-ml
  * the `dask` library is only leveraged directly by rubicon-ml when reading dataframes specified as the "dask" type
    * the "dask" type is never the default, "pandas" is - and `pandas` is still a hard requirement
    * a new error is thrown if users attempt to read a dataframe with a type of "dask" without the `dask` library installed
  * logging `dask` dataframes requires users to already have one to log, so they must have installed `dask` themselves
  * `dask` is still included in the environment as a testing dependency so the tests can still leverage it
    * tests have been updated to ensure new methods work with `dask` and `pandas` dataframes

## How to Test
  * create a new dev environment, then run the tests: `python -m pytest`
  * create a new dev environment, then run the concurrent logging notebook - this one leverages the `to_df` function
