### PR TITLE
tag bugfix

### DIFF
--- a/rubicon_ml/domain/mixin.py
+++ b/rubicon_ml/domain/mixin.py
@@ -1,6 +1,3 @@
-from contextlib import suppress
-
-
 class TagMixin:
     """Adds tagging support to a domain model."""
 
@@ -8,6 +5,4 @@ class TagMixin:
         self.tags = list(set(self.tags).union(set(tags)))
 
     def remove_tags(self, tags):
-        with suppress(ValueError):
-            for tag in tags:
-                self.tags.remove(tag)
+        self.tags = list(set(self.tags).difference(set(tags)))


### PR DESCRIPTION
## What
  * fixes a bug where tag removal was not preserving the proper ordering of operations
    * use set logic for removing tags, just like we have always been for adding them

## How to Test
  * add and remove a bunch of tags from the same thing and make sure the outputs look good

```python
experiment = project.create_experiment(tags=["a", "b"])
print(experiment.tags)  # ["a", "b"]

experiment.add_tags(["c"])
print(experiment.tags)  # ["a", "b", "c"]

experiment.remove_tags(["a", "c"])
print(experiment.tags)  # ["b"]

experiment.add_tags(["d"])
print(experiment.tags)  # ["b", "d"]

experiment.remove_tags(["d"])
print(experiment.tags)  # ["b"]
```
