### PR TITLE
add python 3.11 to test matrix

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     defaults:
       run:
         shell: bash -l {0}

--- a/notebooks/logging-examples/logging-plots.ipynb
+++ b/notebooks/logging-examples/logging-plots.ipynb
@@ -28,12 +28,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: Pillow in /Users/nvd215/mambaforge/envs/rubicon-ml-dev/lib/python3.10/site-packages (9.2.0)\n"
+      "Requirement already satisfied: Pillow in /Users/nvd215/mambaforge/envs/rubicon-ml-dev/lib/python3.10/site-packages (9.2.0)\n",
+      "Requirement already satisfied: kaleido in /Users/nvd215/mambaforge/envs/rubicon-ml-dev/lib/python3.10/site-packages (0.2.1)\n"
      ]
     }
    ],
    "source": [
-    "! pip install Pillow"
+    "! pip install Pillow kaleido"
    ]
   },
   {


### PR DESCRIPTION
## What
  * adds python 3.11 to test matrix in the testing workflow

## How to Test
  * make sure the CI on this branch runs tests for four python versions, 3.8-3.11
