### PR TITLE
add failure modes

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,6 +18,7 @@ clean:
 	rm -rf ./source/quick-look
 	rm -rf ./source/logging-examples
 	rm -rf ./source/integrations
+	rm -rf ./source/tutorials
 	rm -rf ./source/visualizations
 
 # Copy over up to date sources from the root of the `rubicon_ml` repo.
@@ -26,11 +27,13 @@ pre-build:
 	mkdir -p ./source/quick-look
 	mkdir -p ./source/logging-examples
 	mkdir -p ./source/integrations
+	mkdir -p ./source/tutorials
 	mkdir -p ./source/visualizations
 
 	cp ../notebooks/quick-look/*.ipynb ./source/quick-look
 	cp ../notebooks/logging-examples/*.ipynb ./source/logging-examples
 	cp ../notebooks/integrations/*.ipynb ./source/integrations
+	cp ../notebooks/tutorials/*.ipynb ./source/tutorials
 	cp ../notebooks/viz/*.ipynb ./source/visualizations
 
 	cp ../notebooks/quick-look/*.png ./source/quick-look

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -20,11 +20,6 @@
     }
 }
 
-/* hides the dashboard cells' HTTP logs in the examples */
-div.output_area.stderr {
-    display: none;
-}
-
 .hidden {
     display: none;
 }

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -67,6 +67,11 @@ Artifact
 
 .. _library-reference-publish:
 
+exception_handling
+==================
+
+.. autofunction:: rubicon_ml.client.utils.exception_handling.set_failure_mode
+
 publish
 =======
 ``rubicon_ml`` leverages ``intake`` to easily share sets of experiments.

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -70,7 +70,7 @@ Artifact
 exception_handling
 ==================
 
-.. autofunction:: rubicon_ml.client.utils.exception_handling.set_failure_mode
+.. autofunction:: rubicon_ml.set_failure_mode
 
 publish
 =======

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -111,6 +111,7 @@ To install all extra modules, use the ``all`` extra.
    :hidden:
    :caption: Tutorials
 
+   tutorials/failure-modes
    logging-examples/logging-training-metadata
    logging-examples/logging-plots
    logging-examples/logging-concurrently

--- a/notebooks/tutorials/failure-modes.ipynb
+++ b/notebooks/tutorials/failure-modes.ipynb
@@ -32,8 +32,8 @@
       "\nDuring handling of the above exception, another exception occurred:\n",
       "\u001b[0;31mRubiconException\u001b[0m                          Traceback (most recent call last)",
       "Cell \u001b[0;32mIn [1], line 5\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mrubicon_ml\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m Rubicon\n\u001b[1;32m      4\u001b[0m rb \u001b[38;5;241m=\u001b[39m Rubicon(persistence\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmemory\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m----> 5\u001b[0m \u001b[43mrb\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_project\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mfailure modes\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:23\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     21\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     22\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[0;32m---> 23\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m e\n\u001b[1;32m     24\u001b[0m     \u001b[38;5;28;01melif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mwarn\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[1;32m     25\u001b[0m         warnings\u001b[38;5;241m.\u001b[39mwarn(\u001b[38;5;28mrepr\u001b[39m(e))\n",
-      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:20\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     18\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mwrapper\u001b[39m(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m     19\u001b[0m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m---> 20\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     21\u001b[0m     \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     22\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:30\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     28\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     29\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[0;32m---> 30\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m e\n\u001b[1;32m     31\u001b[0m     \u001b[38;5;28;01melif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mwarn\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[1;32m     32\u001b[0m         warnings\u001b[38;5;241m.\u001b[39mwarn(traceback\u001b[38;5;241m.\u001b[39mformat_exc(limit\u001b[38;5;241m=\u001b[39mTRACEBACK_LIMIT, chain\u001b[38;5;241m=\u001b[39mTRACEBACK_CHAIN))\n",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:27\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     25\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mwrapper\u001b[39m(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m     26\u001b[0m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m---> 27\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     28\u001b[0m     \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     29\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n",
       "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/rubicon.py:123\u001b[0m, in \u001b[0;36mRubicon.get_project\u001b[0;34m(self, name, id)\u001b[0m\n\u001b[1;32m    120\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m`name` OR `id` required.\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    122\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m name \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m--> 123\u001b[0m     project \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrepository\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_project\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    124\u001b[0m     project \u001b[38;5;241m=\u001b[39m Project(project, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconfig)\n\u001b[1;32m    125\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n",
       "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/repository/base.py:104\u001b[0m, in \u001b[0;36mBaseRepository.get_project\u001b[0;34m(self, project_name)\u001b[0m\n\u001b[1;32m    102\u001b[0m     project \u001b[38;5;241m=\u001b[39m json\u001b[38;5;241m.\u001b[39mloads(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mfilesystem\u001b[38;5;241m.\u001b[39mcat(project_metadata_path))\n\u001b[1;32m    103\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mFileNotFoundError\u001b[39;00m:\n\u001b[0;32m--> 104\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m RubiconException(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mNo project with name \u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mproject_name\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m found.\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    106\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m domain\u001b[38;5;241m.\u001b[39mProject(\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mproject)\n",
       "\u001b[0;31mRubiconException\u001b[0m: No project with name 'failure modes' found."
@@ -58,8 +58,16 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:25: UserWarning: RubiconException(\"No project with name 'failure modes' found.\")\n",
-      "  warnings.warn(repr(e))\n"
+      "/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:32: UserWarning: Traceback (most recent call last):\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py\", line 27, in wrapper\n",
+      "    return func(*args, **kwargs)\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/rubicon.py\", line 123, in get_project\n",
+      "    project = self.repository.get_project(name)\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/repository/base.py\", line 104, in get_project\n",
+      "    raise RubiconException(f\"No project with name '{project_name}' found.\")\n",
+      "rubicon_ml.exceptions.RubiconException: No project with name 'failure modes' found.\n",
+      "\n",
+      "  warnings.warn(traceback.format_exc(limit=TRACEBACK_LIMIT, chain=TRACEBACK_CHAIN))\n"
      ]
     }
    ],
@@ -82,7 +90,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ERROR:root:RubiconException(\"No project with name 'failure modes' found.\")\n"
+      "ERROR:root:Traceback (most recent call last):\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py\", line 27, in wrapper\n",
+      "    return func(*args, **kwargs)\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/rubicon.py\", line 123, in get_project\n",
+      "    project = self.repository.get_project(name)\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/repository/base.py\", line 104, in get_project\n",
+      "    raise RubiconException(f\"No project with name '{project_name}' found.\")\n",
+      "rubicon_ml.exceptions.RubiconException: No project with name 'failure modes' found.\n",
+      "\n"
      ]
     }
    ],
@@ -97,7 +113,76 @@
    "id": "ec648cde-0d9d-4d29-83f5-e58d090eb150",
    "metadata": {},
    "source": [
-    "text about setting back to \"raise\" for default behavior"
+    "text about setting back to \"raise\" for default behavior\n",
+    "\n",
+    "### verbosity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "214a0d51-89bd-4c10-833f-60463517af7f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR:root:rubicon_ml.exceptions.RubiconException: No project with name 'failure modes' found.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "set_failure_mode(\"log\", traceback_limit=0)\n",
+    "\n",
+    "rb.get_project(name=\"failure modes\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "86516e95-02e7-40a8-b474-672bdabe19f2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR:root:Traceback (most recent call last):\n",
+      "  File \"/Users/nvd215/mambaforge/envs/rubicon-ml-dev/lib/python3.10/site-packages/fsspec/implementations/memory.py\", line 213, in cat_file\n",
+      "    return bytes(self.store[path].getbuffer()[start:end])\n",
+      "KeyError: '/root/failure-modes/metadata.json'\n",
+      "\n",
+      "During handling of the above exception, another exception occurred:\n",
+      "\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/repository/base.py\", line 102, in get_project\n",
+      "    project = json.loads(self.filesystem.cat(project_metadata_path))\n",
+      "  File \"/Users/nvd215/mambaforge/envs/rubicon-ml-dev/lib/python3.10/site-packages/fsspec/spec.py\", line 755, in cat\n",
+      "    return self.cat_file(paths[0], **kwargs)\n",
+      "  File \"/Users/nvd215/mambaforge/envs/rubicon-ml-dev/lib/python3.10/site-packages/fsspec/implementations/memory.py\", line 215, in cat_file\n",
+      "    raise FileNotFoundError(path)\n",
+      "FileNotFoundError: /root/failure-modes/metadata.json\n",
+      "\n",
+      "During handling of the above exception, another exception occurred:\n",
+      "\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py\", line 27, in wrapper\n",
+      "    return func(*args, **kwargs)\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/rubicon.py\", line 123, in get_project\n",
+      "    project = self.repository.get_project(name)\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/repository/base.py\", line 104, in get_project\n",
+      "    raise RubiconException(f\"No project with name '{project_name}' found.\")\n",
+      "rubicon_ml.exceptions.RubiconException: No project with name 'failure modes' found.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "set_failure_mode(\"log\", traceback_chain=True)\n",
+    "\n",
+    "rb.get_project(name=\"failure modes\")"
    ]
   },
   {
@@ -110,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "fd1815bf-3482-47a1-820c-ecfb5d82d6e2",
    "metadata": {},
    "outputs": [
@@ -118,7 +203,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Project(name='failure modes', id='1f71926a-8445-48bb-90b0-9a8a47fd2321', description=None, github_url=None, training_metadata=None, created_at=datetime.datetime(2022, 11, 15, 0, 41, 22, 738553))\n"
+      "Project(name='failure modes', id='1790ba2e-363f-4982-bf98-a117d1474826', description=None, github_url=None, training_metadata=None, created_at=datetime.datetime(2022, 11, 15, 14, 26, 27, 485224))\n"
      ]
     }
    ],
@@ -131,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "c603cc65-ca2f-4877-ae89-bde97420af34",
    "metadata": {},
    "outputs": [
@@ -139,7 +224,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ERROR:root:RubiconException(\"No project with name 'failure modes v2' found.\")\n"
+      "ERROR:root:Traceback (most recent call last):\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py\", line 27, in wrapper\n",
+      "    return func(*args, **kwargs)\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/rubicon.py\", line 123, in get_project\n",
+      "    project = self.repository.get_project(name)\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/repository/base.py\", line 104, in get_project\n",
+      "    raise RubiconException(f\"No project with name '{project_name}' found.\")\n",
+      "rubicon_ml.exceptions.RubiconException: No project with name 'failure modes v2' found.\n",
+      "\n"
      ]
     },
     {
@@ -167,7 +260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "1d4dd196-e640-4df8-8718-e4187e5cefe6",
    "metadata": {},
    "outputs": [],
@@ -183,17 +276,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "e76935dd-a711-4c30-b37a-a3a209410d30",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<rubicon_ml.client.experiment.Experiment at 0x16804ab00>"
+       "<rubicon_ml.client.experiment.Experiment at 0x164326f80>"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -207,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "97952405-95b8-446f-a5f6-1d868d56aa1f",
    "metadata": {},
    "outputs": [],
@@ -217,7 +310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "7cac1030-71d2-4c57-a76b-16d50778ee06",
    "metadata": {},
    "outputs": [
@@ -228,9 +321,9 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn [9], line 5\u001b[0m\n\u001b[1;32m      2\u001b[0m X_train, y_train, X_test, y_test \u001b[38;5;241m=\u001b[39m [[\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m3\u001b[39m]], [\u001b[38;5;241m0\u001b[39m], [[\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m3\u001b[39m]], [\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m      4\u001b[0m knn\u001b[38;5;241m.\u001b[39mfit(X_train, y_train)\n\u001b[0;32m----> 5\u001b[0m \u001b[43mexperiment\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlog_parameter\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mn_neighbors\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mvalue\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m1\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m      7\u001b[0m score \u001b[38;5;241m=\u001b[39m knn\u001b[38;5;241m.\u001b[39mscore(X_test, y_test)\n\u001b[1;32m      8\u001b[0m experiment\u001b[38;5;241m.\u001b[39mlog_metric(name\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mscore\u001b[39m\u001b[38;5;124m\"\u001b[39m, value\u001b[38;5;241m=\u001b[39mscore)\n",
-      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:23\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     21\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     22\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[0;32m---> 23\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m e\n\u001b[1;32m     24\u001b[0m     \u001b[38;5;28;01melif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mwarn\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[1;32m     25\u001b[0m         warnings\u001b[38;5;241m.\u001b[39mwarn(\u001b[38;5;28mrepr\u001b[39m(e))\n",
-      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:20\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     18\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mwrapper\u001b[39m(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m     19\u001b[0m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m---> 20\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     21\u001b[0m     \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     22\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n",
+      "Cell \u001b[0;32mIn [11], line 5\u001b[0m\n\u001b[1;32m      2\u001b[0m X_train, y_train, X_test, y_test \u001b[38;5;241m=\u001b[39m [[\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m3\u001b[39m]], [\u001b[38;5;241m0\u001b[39m], [[\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m3\u001b[39m]], [\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m      4\u001b[0m knn\u001b[38;5;241m.\u001b[39mfit(X_train, y_train)\n\u001b[0;32m----> 5\u001b[0m \u001b[43mexperiment\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlog_parameter\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mn_neighbors\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mvalue\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m1\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m      7\u001b[0m score \u001b[38;5;241m=\u001b[39m knn\u001b[38;5;241m.\u001b[39mscore(X_test, y_test)\n\u001b[1;32m      8\u001b[0m experiment\u001b[38;5;241m.\u001b[39mlog_metric(name\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mscore\u001b[39m\u001b[38;5;124m\"\u001b[39m, value\u001b[38;5;241m=\u001b[39mscore)\n",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:30\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     28\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     29\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[0;32m---> 30\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m e\n\u001b[1;32m     31\u001b[0m     \u001b[38;5;28;01melif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mwarn\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[1;32m     32\u001b[0m         warnings\u001b[38;5;241m.\u001b[39mwarn(traceback\u001b[38;5;241m.\u001b[39mformat_exc(limit\u001b[38;5;241m=\u001b[39mTRACEBACK_LIMIT, chain\u001b[38;5;241m=\u001b[39mTRACEBACK_CHAIN))\n",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:27\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     25\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mwrapper\u001b[39m(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m     26\u001b[0m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m---> 27\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     28\u001b[0m     \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     29\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n",
       "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/experiment.py:237\u001b[0m, in \u001b[0;36mExperiment.log_parameter\u001b[0;34m(self, name, value, description, tags)\u001b[0m\n\u001b[1;32m    214\u001b[0m \u001b[38;5;124;03m\"\"\"Create a parameter under the experiment.\u001b[39;00m\n\u001b[1;32m    215\u001b[0m \n\u001b[1;32m    216\u001b[0m \u001b[38;5;124;03mParameters\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    234\u001b[0m \u001b[38;5;124;03m    The created parameter.\u001b[39;00m\n\u001b[1;32m    235\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    236\u001b[0m parameter \u001b[38;5;241m=\u001b[39m domain\u001b[38;5;241m.\u001b[39mParameter(name, value\u001b[38;5;241m=\u001b[39mvalue, description\u001b[38;5;241m=\u001b[39mdescription, tags\u001b[38;5;241m=\u001b[39mtags)\n\u001b[0;32m--> 237\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrepository\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcreate_parameter\u001b[49m\u001b[43m(\u001b[49m\u001b[43mparameter\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mproject\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mname\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mid\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    239\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m Parameter(parameter, \u001b[38;5;28mself\u001b[39m)\n",
       "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/repository/base.py:852\u001b[0m, in \u001b[0;36mBaseRepository.create_parameter\u001b[0;34m(self, parameter, project_name, experiment_id)\u001b[0m\n\u001b[1;32m    836\u001b[0m \u001b[38;5;124;03m\"\"\"Persist a parameter to the configured filesystem.\u001b[39;00m\n\u001b[1;32m    837\u001b[0m \n\u001b[1;32m    838\u001b[0m \u001b[38;5;124;03mParameters\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    846\u001b[0m \u001b[38;5;124;03m    The ID of the experiment this parameter belongs to.\u001b[39;00m\n\u001b[1;32m    847\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    848\u001b[0m parameter_metadata_path \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_get_parameter_metadata_path(\n\u001b[1;32m    849\u001b[0m     project_name, experiment_id, parameter\u001b[38;5;241m.\u001b[39mname\n\u001b[1;32m    850\u001b[0m )\n\u001b[0;32m--> 852\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfilesystem\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexists\u001b[49m(parameter_metadata_path):\n\u001b[1;32m    853\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m RubiconException(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mA parameter with name \u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mparameter\u001b[38;5;241m.\u001b[39mname\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m already exists.\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    855\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_persist_domain(parameter, parameter_metadata_path)\n",
       "\u001b[0;31mAttributeError\u001b[0m: 'BrokenFilesystem' object has no attribute 'exists'"
@@ -252,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "2c2556ce-e11f-4173-9e3a-f041dda56e98",
    "metadata": {},
    "outputs": [
@@ -260,8 +353,24 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ERROR:root:AttributeError(\"'BrokenFilesystem' object has no attribute 'exists'\")\n",
-      "ERROR:root:AttributeError(\"'BrokenFilesystem' object has no attribute 'exists'\")\n"
+      "ERROR:root:Traceback (most recent call last):\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py\", line 27, in wrapper\n",
+      "    return func(*args, **kwargs)\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/experiment.py\", line 237, in log_parameter\n",
+      "    self.repository.create_parameter(parameter, self.project.name, self.id)\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/repository/base.py\", line 852, in create_parameter\n",
+      "    if self.filesystem.exists(parameter_metadata_path):\n",
+      "AttributeError: 'BrokenFilesystem' object has no attribute 'exists'\n",
+      "\n",
+      "ERROR:root:Traceback (most recent call last):\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py\", line 27, in wrapper\n",
+      "    return func(*args, **kwargs)\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/experiment.py\", line 76, in log_metric\n",
+      "    self.repository.create_metric(metric, self.project.name, self.id)\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/repository/base.py\", line 746, in create_metric\n",
+      "    if self.filesystem.exists(metric_metadata_path):\n",
+      "AttributeError: 'BrokenFilesystem' object has no attribute 'exists'\n",
+      "\n"
      ]
     },
     {
@@ -270,7 +379,7 @@
        "1.0"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/notebooks/tutorials/failure-modes.ipynb
+++ b/notebooks/tutorials/failure-modes.ipynb
@@ -1,0 +1,232 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7de3eb73-75e0-43b3-887e-329773a72bf0",
+   "metadata": {},
+   "source": [
+    "# Failure Modes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "682ab147-2963-413c-9e5b-5caf52198229",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rubicon_ml import Rubicon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3c67e5ab-ed7b-4daa-957f-7b32d71a7c46",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<rubicon_ml.client.project.Project at 0x1589a9f90>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rb = Rubicon(persistence=\"memory\")\n",
+    "pr = rb.get_or_create_project(name=\"failure modes\")\n",
+    "pr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c68859a1-2a23-4fc4-8e04-37476ad78e59",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Experiment(project_name='failure modes', id='00cf6134-6b54-46f4-9ba6-6ae3d4c2d2db', name=None, description=None, model_name=None, branch_name=None, commit_hash=None, training_metadata=None, tags=[], created_at=datetime.datetime(2022, 11, 10, 21, 35, 55, 898051))"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ex = pr.log_experiment()\n",
+    "ex._domain"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c9829b85-bd13-4875-baf9-d312f5396439",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<rubicon_ml.client.experiment.Experiment at 0x1589ab460>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pr.log_experiment(tags=[\"a\", \"b\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "24e1170f-603d-49c1-8914-bc7fbc5a0bb5",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "Project.log_experiment() got an unexpected keyword argument 'bad_arg'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn [5], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mpr\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlog_experiment\u001b[49m\u001b[43m(\u001b[49m\u001b[43mbad_arg\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:21\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     19\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     20\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[0;32m---> 21\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m(e)\n\u001b[1;32m     22\u001b[0m     \u001b[38;5;28;01melif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mwarn\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[1;32m     23\u001b[0m         warnings\u001b[38;5;241m.\u001b[39mwarn(\u001b[38;5;28mrepr\u001b[39m(e))\n",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:18\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     16\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mwrapper\u001b[39m(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m     17\u001b[0m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m---> 18\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     19\u001b[0m     \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     20\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n",
+      "\u001b[0;31mTypeError\u001b[0m: Project.log_experiment() got an unexpected keyword argument 'bad_arg'"
+     ]
+    }
+   ],
+   "source": [
+    "pr.log_experiment(bad_arg=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b05c2dee-8d25-4478-8027-c385f23d73f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rubicon_ml.client.utils.exception_handling import set_failure_mode"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "52e59ec9-6ae7-4f6c-9d87-dc4e1948b6f1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:23: UserWarning: TypeError(\"Project.log_experiment() got an unexpected keyword argument 'bad_arg'\")\n",
+      "  warnings.warn(repr(e))\n"
+     ]
+    }
+   ],
+   "source": [
+    "set_failure_mode(\"warn\")\n",
+    "\n",
+    "pr.log_experiment(bad_arg=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "bf6f22cf-e61e-4c80-86e9-b5a49b4dfb24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR:root:TypeError(\"Project.log_experiment() got an unexpected keyword argument 'bad_arg'\")\n"
+     ]
+    }
+   ],
+   "source": [
+    "set_failure_mode(\"log\")\n",
+    "\n",
+    "pr.log_experiment(bad_arg=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "191b15c8-0497-4b36-87cd-893c36cf6252",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "`failure_mode` must be one of ['log', 'raise', 'warn']",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn [9], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mset_failure_mode\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mfail\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m      3\u001b[0m pr\u001b[38;5;241m.\u001b[39mlog_experiment(bad_arg\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m)\n",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:11\u001b[0m, in \u001b[0;36mset_failure_mode\u001b[0;34m(failure_mode)\u001b[0m\n\u001b[1;32m      8\u001b[0m \u001b[38;5;28;01mglobal\u001b[39;00m FAILURE_MODE\n\u001b[1;32m     10\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m failure_mode \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m FAILURE_MODES:\n\u001b[0;32m---> 11\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m`failure_mode` must be one of \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mFAILURE_MODES\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m     13\u001b[0m FAILURE_MODE \u001b[38;5;241m=\u001b[39m failure_mode\n",
+      "\u001b[0;31mValueError\u001b[0m: `failure_mode` must be one of ['log', 'raise', 'warn']"
+     ]
+    }
+   ],
+   "source": [
+    "set_failure_mode(\"fail\")\n",
+    "\n",
+    "pr.log_experiment(bad_arg=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "23ab6659-812e-4246-a4cf-48743af5c9e4",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "`failure_mode` must be one of ['log', 'raise', 'warn']",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn [10], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mset_failure_mode\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:11\u001b[0m, in \u001b[0;36mset_failure_mode\u001b[0;34m(failure_mode)\u001b[0m\n\u001b[1;32m      8\u001b[0m \u001b[38;5;28;01mglobal\u001b[39;00m FAILURE_MODE\n\u001b[1;32m     10\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m failure_mode \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m FAILURE_MODES:\n\u001b[0;32m---> 11\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m`failure_mode` must be one of \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mFAILURE_MODES\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m     13\u001b[0m FAILURE_MODE \u001b[38;5;241m=\u001b[39m failure_mode\n",
+      "\u001b[0;31mValueError\u001b[0m: `failure_mode` must be one of ['log', 'raise', 'warn']"
+     ]
+    }
+   ],
+   "source": [
+    "set_failure_mode(None)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/tutorials/failure-modes.ipynb
+++ b/notebooks/tutorials/failure-modes.ipynb
@@ -40,8 +40,8 @@
       "\nDuring handling of the above exception, another exception occurred:\n",
       "\u001b[0;31mRubiconException\u001b[0m                          Traceback (most recent call last)",
       "Cell \u001b[0;32mIn [1], line 5\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mrubicon_ml\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m Rubicon\n\u001b[1;32m      4\u001b[0m rb \u001b[38;5;241m=\u001b[39m Rubicon(persistence\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmemory\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m----> 5\u001b[0m \u001b[43mrb\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_project\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mfailure modes\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:30\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     28\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     29\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[0;32m---> 30\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m e\n\u001b[1;32m     31\u001b[0m     \u001b[38;5;28;01melif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mwarn\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[1;32m     32\u001b[0m         warnings\u001b[38;5;241m.\u001b[39mwarn(traceback\u001b[38;5;241m.\u001b[39mformat_exc(limit\u001b[38;5;241m=\u001b[39mTRACEBACK_LIMIT, chain\u001b[38;5;241m=\u001b[39mTRACEBACK_CHAIN))\n",
-      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:27\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     25\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mwrapper\u001b[39m(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m     26\u001b[0m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m---> 27\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     28\u001b[0m     \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     29\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:46\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     44\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     45\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[0;32m---> 46\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m e\n\u001b[1;32m     47\u001b[0m     \u001b[38;5;28;01melif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mwarn\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[1;32m     48\u001b[0m         warnings\u001b[38;5;241m.\u001b[39mwarn(traceback\u001b[38;5;241m.\u001b[39mformat_exc(limit\u001b[38;5;241m=\u001b[39mTRACEBACK_LIMIT, chain\u001b[38;5;241m=\u001b[39mTRACEBACK_CHAIN))\n",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:43\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     41\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mwrapper\u001b[39m(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m     42\u001b[0m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m---> 43\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     44\u001b[0m     \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     45\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n",
       "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/rubicon.py:123\u001b[0m, in \u001b[0;36mRubicon.get_project\u001b[0;34m(self, name, id)\u001b[0m\n\u001b[1;32m    120\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m`name` OR `id` required.\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    122\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m name \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m--> 123\u001b[0m     project \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrepository\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_project\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    124\u001b[0m     project \u001b[38;5;241m=\u001b[39m Project(project, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconfig)\n\u001b[1;32m    125\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n",
       "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/repository/base.py:104\u001b[0m, in \u001b[0;36mBaseRepository.get_project\u001b[0;34m(self, project_name)\u001b[0m\n\u001b[1;32m    102\u001b[0m     project \u001b[38;5;241m=\u001b[39m json\u001b[38;5;241m.\u001b[39mloads(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mfilesystem\u001b[38;5;241m.\u001b[39mcat(project_metadata_path))\n\u001b[1;32m    103\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mFileNotFoundError\u001b[39;00m:\n\u001b[0;32m--> 104\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m RubiconException(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mNo project with name \u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mproject_name\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m found.\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    106\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m domain\u001b[38;5;241m.\u001b[39mProject(\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mproject)\n",
       "\u001b[0;31mRubiconException\u001b[0m: No project with name 'failure modes' found."
@@ -78,8 +78,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:32: UserWarning: Traceback (most recent call last):\n",
-      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py\", line 27, in wrapper\n",
+      "/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:48: UserWarning: Traceback (most recent call last):\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py\", line 43, in wrapper\n",
       "    return func(*args, **kwargs)\n",
       "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/rubicon.py\", line 123, in get_project\n",
       "    project = self.repository.get_project(name)\n",
@@ -92,7 +92,7 @@
     }
    ],
    "source": [
-    "from rubicon_ml.client.utils.exception_handling import set_failure_mode\n",
+    "from rubicon_ml import set_failure_mode\n",
     "\n",
     "\n",
     "set_failure_mode(\"warn\")\n",
@@ -119,7 +119,7 @@
      "output_type": "stream",
      "text": [
       "ERROR:root:Traceback (most recent call last):\n",
-      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py\", line 27, in wrapper\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py\", line 43, in wrapper\n",
       "    return func(*args, **kwargs)\n",
       "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/rubicon.py\", line 123, in get_project\n",
       "    project = self.repository.get_project(name)\n",
@@ -211,7 +211,7 @@
       "During handling of the above exception, another exception occurred:\n",
       "\n",
       "Traceback (most recent call last):\n",
-      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py\", line 27, in wrapper\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py\", line 43, in wrapper\n",
       "    return func(*args, **kwargs)\n",
       "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/rubicon.py\", line 123, in get_project\n",
       "    project = self.repository.get_project(name)\n",
@@ -250,7 +250,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Project(name='failure modes', id='ddef2b43-cdc0-4ebf-93a9-26bd93bf1f42', description=None, github_url=None, training_metadata=None, created_at=datetime.datetime(2022, 11, 15, 16, 3, 40, 999293))\n"
+      "Project(name='failure modes', id='8d6ac09b-45c5-4097-9728-302c481a1665', description=None, github_url=None, training_metadata=None, created_at=datetime.datetime(2022, 11, 15, 17, 5, 2, 510729))\n"
      ]
     }
    ],
@@ -279,7 +279,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ddef2b43-cdc0-4ebf-93a9-26bd93bf1f42\n"
+      "8d6ac09b-45c5-4097-9728-302c481a1665\n"
      ]
     }
    ],
@@ -312,7 +312,7 @@
      "output_type": "stream",
      "text": [
       "ERROR:root:Traceback (most recent call last):\n",
-      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py\", line 27, in wrapper\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py\", line 43, in wrapper\n",
       "    return func(*args, **kwargs)\n",
       "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/rubicon.py\", line 123, in get_project\n",
       "    project = self.repository.get_project(name)\n",
@@ -381,7 +381,7 @@
     {
      "data": {
       "text/plain": [
-       "<rubicon_ml.client.experiment.Experiment at 0x16055e320>"
+       "<rubicon_ml.client.experiment.Experiment at 0x15cacce20>"
       ]
      },
      "execution_count": 10,
@@ -448,8 +448,8 @@
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
       "Cell \u001b[0;32mIn [12], line 8\u001b[0m\n\u001b[1;32m      5\u001b[0m X_train, y_train, X_test, y_test \u001b[38;5;241m=\u001b[39m [[\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m3\u001b[39m]], [\u001b[38;5;241m0\u001b[39m], [[\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m3\u001b[39m]], [\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m      7\u001b[0m knn\u001b[38;5;241m.\u001b[39mfit(X_train, y_train)\n\u001b[0;32m----> 8\u001b[0m \u001b[43mexperiment\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlog_parameter\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mn_neighbors\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mvalue\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m1\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m     10\u001b[0m score \u001b[38;5;241m=\u001b[39m knn\u001b[38;5;241m.\u001b[39mscore(X_test, y_test)\n\u001b[1;32m     11\u001b[0m experiment\u001b[38;5;241m.\u001b[39mlog_metric(name\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mscore\u001b[39m\u001b[38;5;124m\"\u001b[39m, value\u001b[38;5;241m=\u001b[39mscore)\n",
-      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:30\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     28\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     29\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[0;32m---> 30\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m e\n\u001b[1;32m     31\u001b[0m     \u001b[38;5;28;01melif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mwarn\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[1;32m     32\u001b[0m         warnings\u001b[38;5;241m.\u001b[39mwarn(traceback\u001b[38;5;241m.\u001b[39mformat_exc(limit\u001b[38;5;241m=\u001b[39mTRACEBACK_LIMIT, chain\u001b[38;5;241m=\u001b[39mTRACEBACK_CHAIN))\n",
-      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:27\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     25\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mwrapper\u001b[39m(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m     26\u001b[0m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m---> 27\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     28\u001b[0m     \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     29\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:46\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     44\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     45\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[0;32m---> 46\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m e\n\u001b[1;32m     47\u001b[0m     \u001b[38;5;28;01melif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mwarn\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[1;32m     48\u001b[0m         warnings\u001b[38;5;241m.\u001b[39mwarn(traceback\u001b[38;5;241m.\u001b[39mformat_exc(limit\u001b[38;5;241m=\u001b[39mTRACEBACK_LIMIT, chain\u001b[38;5;241m=\u001b[39mTRACEBACK_CHAIN))\n",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:43\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     41\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mwrapper\u001b[39m(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m     42\u001b[0m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m---> 43\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     44\u001b[0m     \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     45\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n",
       "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/experiment.py:237\u001b[0m, in \u001b[0;36mExperiment.log_parameter\u001b[0;34m(self, name, value, description, tags)\u001b[0m\n\u001b[1;32m    214\u001b[0m \u001b[38;5;124;03m\"\"\"Create a parameter under the experiment.\u001b[39;00m\n\u001b[1;32m    215\u001b[0m \n\u001b[1;32m    216\u001b[0m \u001b[38;5;124;03mParameters\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    234\u001b[0m \u001b[38;5;124;03m    The created parameter.\u001b[39;00m\n\u001b[1;32m    235\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    236\u001b[0m parameter \u001b[38;5;241m=\u001b[39m domain\u001b[38;5;241m.\u001b[39mParameter(name, value\u001b[38;5;241m=\u001b[39mvalue, description\u001b[38;5;241m=\u001b[39mdescription, tags\u001b[38;5;241m=\u001b[39mtags)\n\u001b[0;32m--> 237\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrepository\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcreate_parameter\u001b[49m\u001b[43m(\u001b[49m\u001b[43mparameter\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mproject\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mname\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mid\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    239\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m Parameter(parameter, \u001b[38;5;28mself\u001b[39m)\n",
       "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/repository/base.py:852\u001b[0m, in \u001b[0;36mBaseRepository.create_parameter\u001b[0;34m(self, parameter, project_name, experiment_id)\u001b[0m\n\u001b[1;32m    836\u001b[0m \u001b[38;5;124;03m\"\"\"Persist a parameter to the configured filesystem.\u001b[39;00m\n\u001b[1;32m    837\u001b[0m \n\u001b[1;32m    838\u001b[0m \u001b[38;5;124;03mParameters\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    846\u001b[0m \u001b[38;5;124;03m    The ID of the experiment this parameter belongs to.\u001b[39;00m\n\u001b[1;32m    847\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    848\u001b[0m parameter_metadata_path \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_get_parameter_metadata_path(\n\u001b[1;32m    849\u001b[0m     project_name, experiment_id, parameter\u001b[38;5;241m.\u001b[39mname\n\u001b[1;32m    850\u001b[0m )\n\u001b[0;32m--> 852\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfilesystem\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexists\u001b[49m(parameter_metadata_path):\n\u001b[1;32m    853\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m RubiconException(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mA parameter with name \u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mparameter\u001b[38;5;241m.\u001b[39mname\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m already exists.\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    855\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_persist_domain(parameter, parameter_metadata_path)\n",
       "\u001b[0;31mAttributeError\u001b[0m: 'BrokenFilesystem' object has no attribute 'exists'"
@@ -493,7 +493,7 @@
      "output_type": "stream",
      "text": [
       "ERROR:root:Traceback (most recent call last):\n",
-      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py\", line 27, in wrapper\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py\", line 43, in wrapper\n",
       "    return func(*args, **kwargs)\n",
       "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/experiment.py\", line 237, in log_parameter\n",
       "    self.repository.create_parameter(parameter, self.project.name, self.id)\n",
@@ -502,7 +502,7 @@
       "AttributeError: 'BrokenFilesystem' object has no attribute 'exists'\n",
       "\n",
       "ERROR:root:Traceback (most recent call last):\n",
-      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py\", line 27, in wrapper\n",
+      "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py\", line 43, in wrapper\n",
       "    return func(*args, **kwargs)\n",
       "  File \"/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/experiment.py\", line 76, in log_metric\n",
       "    self.repository.create_metric(metric, self.project.name, self.id)\n",

--- a/notebooks/tutorials/failure-modes.ipynb
+++ b/notebooks/tutorials/failure-modes.ipynb
@@ -11,200 +11,283 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "682ab147-2963-413c-9e5b-5caf52198229",
+   "id": "b650c884-51cd-41bb-b035-bddfd3de15f4",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "RubiconException",
+     "evalue": "No project with name 'failure modes' found.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "File \u001b[0;32m~/mambaforge/envs/rubicon-ml-dev/lib/python3.10/site-packages/fsspec/implementations/memory.py:213\u001b[0m, in \u001b[0;36mMemoryFileSystem.cat_file\u001b[0;34m(self, path, start, end, **kwargs)\u001b[0m\n\u001b[1;32m    212\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m--> 213\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mbytes\u001b[39m(\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mstore\u001b[49m\u001b[43m[\u001b[49m\u001b[43mpath\u001b[49m\u001b[43m]\u001b[49m\u001b[38;5;241m.\u001b[39mgetbuffer()[start:end])\n\u001b[1;32m    214\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m:\n",
+      "\u001b[0;31mKeyError\u001b[0m: '/root/failure-modes/metadata.json'",
+      "\nDuring handling of the above exception, another exception occurred:\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/repository/base.py:102\u001b[0m, in \u001b[0;36mBaseRepository.get_project\u001b[0;34m(self, project_name)\u001b[0m\n\u001b[1;32m    101\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m--> 102\u001b[0m     project \u001b[38;5;241m=\u001b[39m json\u001b[38;5;241m.\u001b[39mloads(\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfilesystem\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mproject_metadata_path\u001b[49m\u001b[43m)\u001b[49m)\n\u001b[1;32m    103\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mFileNotFoundError\u001b[39;00m:\n",
+      "File \u001b[0;32m~/mambaforge/envs/rubicon-ml-dev/lib/python3.10/site-packages/fsspec/spec.py:755\u001b[0m, in \u001b[0;36mAbstractFileSystem.cat\u001b[0;34m(self, path, recursive, on_error, **kwargs)\u001b[0m\n\u001b[1;32m    754\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m--> 755\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcat_file\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpaths\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/mambaforge/envs/rubicon-ml-dev/lib/python3.10/site-packages/fsspec/implementations/memory.py:215\u001b[0m, in \u001b[0;36mMemoryFileSystem.cat_file\u001b[0;34m(self, path, start, end, **kwargs)\u001b[0m\n\u001b[1;32m    214\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m:\n\u001b[0;32m--> 215\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mFileNotFoundError\u001b[39;00m(path)\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: /root/failure-modes/metadata.json",
+      "\nDuring handling of the above exception, another exception occurred:\n",
+      "\u001b[0;31mRubiconException\u001b[0m                          Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn [1], line 5\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mrubicon_ml\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m Rubicon\n\u001b[1;32m      4\u001b[0m rb \u001b[38;5;241m=\u001b[39m Rubicon(persistence\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmemory\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m----> 5\u001b[0m \u001b[43mrb\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_project\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mfailure modes\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:23\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     21\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     22\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[0;32m---> 23\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m e\n\u001b[1;32m     24\u001b[0m     \u001b[38;5;28;01melif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mwarn\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[1;32m     25\u001b[0m         warnings\u001b[38;5;241m.\u001b[39mwarn(\u001b[38;5;28mrepr\u001b[39m(e))\n",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:20\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     18\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mwrapper\u001b[39m(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m     19\u001b[0m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m---> 20\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     21\u001b[0m     \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     22\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/rubicon.py:123\u001b[0m, in \u001b[0;36mRubicon.get_project\u001b[0;34m(self, name, id)\u001b[0m\n\u001b[1;32m    120\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m`name` OR `id` required.\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    122\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m name \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m--> 123\u001b[0m     project \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrepository\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_project\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    124\u001b[0m     project \u001b[38;5;241m=\u001b[39m Project(project, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconfig)\n\u001b[1;32m    125\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/repository/base.py:104\u001b[0m, in \u001b[0;36mBaseRepository.get_project\u001b[0;34m(self, project_name)\u001b[0m\n\u001b[1;32m    102\u001b[0m     project \u001b[38;5;241m=\u001b[39m json\u001b[38;5;241m.\u001b[39mloads(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mfilesystem\u001b[38;5;241m.\u001b[39mcat(project_metadata_path))\n\u001b[1;32m    103\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mFileNotFoundError\u001b[39;00m:\n\u001b[0;32m--> 104\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m RubiconException(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mNo project with name \u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mproject_name\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m found.\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    106\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m domain\u001b[38;5;241m.\u001b[39mProject(\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mproject)\n",
+      "\u001b[0;31mRubiconException\u001b[0m: No project with name 'failure modes' found."
+     ]
+    }
+   ],
    "source": [
-    "from rubicon_ml import Rubicon"
+    "from rubicon_ml import Rubicon\n",
+    "\n",
+    "\n",
+    "rb = Rubicon(persistence=\"memory\")\n",
+    "rb.get_project(name=\"failure modes\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "3c67e5ab-ed7b-4daa-957f-7b32d71a7c46",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<rubicon_ml.client.project.Project at 0x1589a9f90>"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "rb = Rubicon(persistence=\"memory\")\n",
-    "pr = rb.get_or_create_project(name=\"failure modes\")\n",
-    "pr"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "c68859a1-2a23-4fc4-8e04-37476ad78e59",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Experiment(project_name='failure modes', id='00cf6134-6b54-46f4-9ba6-6ae3d4c2d2db', name=None, description=None, model_name=None, branch_name=None, commit_hash=None, training_metadata=None, tags=[], created_at=datetime.datetime(2022, 11, 10, 21, 35, 55, 898051))"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ex = pr.log_experiment()\n",
-    "ex._domain"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "c9829b85-bd13-4875-baf9-d312f5396439",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<rubicon_ml.client.experiment.Experiment at 0x1589ab460>"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pr.log_experiment(tags=[\"a\", \"b\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "24e1170f-603d-49c1-8914-bc7fbc5a0bb5",
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "Project.log_experiment() got an unexpected keyword argument 'bad_arg'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn [5], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mpr\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlog_experiment\u001b[49m\u001b[43m(\u001b[49m\u001b[43mbad_arg\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:21\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     19\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     20\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[0;32m---> 21\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m(e)\n\u001b[1;32m     22\u001b[0m     \u001b[38;5;28;01melif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mwarn\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[1;32m     23\u001b[0m         warnings\u001b[38;5;241m.\u001b[39mwarn(\u001b[38;5;28mrepr\u001b[39m(e))\n",
-      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:18\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     16\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mwrapper\u001b[39m(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m     17\u001b[0m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m---> 18\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     19\u001b[0m     \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     20\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n",
-      "\u001b[0;31mTypeError\u001b[0m: Project.log_experiment() got an unexpected keyword argument 'bad_arg'"
-     ]
-    }
-   ],
-   "source": [
-    "pr.log_experiment(bad_arg=None)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "b05c2dee-8d25-4478-8027-c385f23d73f7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from rubicon_ml.client.utils.exception_handling import set_failure_mode"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "52e59ec9-6ae7-4f6c-9d87-dc4e1948b6f1",
+   "id": "457871b9-cb20-49b8-847e-bf563fbb255f",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:23: UserWarning: TypeError(\"Project.log_experiment() got an unexpected keyword argument 'bad_arg'\")\n",
+      "/Users/nvd215/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:25: UserWarning: RubiconException(\"No project with name 'failure modes' found.\")\n",
       "  warnings.warn(repr(e))\n"
      ]
     }
    ],
    "source": [
+    "from rubicon_ml.client.utils.exception_handling import set_failure_mode\n",
+    "\n",
+    "\n",
     "set_failure_mode(\"warn\")\n",
     "\n",
-    "pr.log_experiment(bad_arg=None)"
+    "rb.get_project(name=\"failure modes\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "bf6f22cf-e61e-4c80-86e9-b5a49b4dfb24",
+   "execution_count": 3,
+   "id": "bbbbdb5d-3d90-45b6-8ab0-df70cab60074",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ERROR:root:TypeError(\"Project.log_experiment() got an unexpected keyword argument 'bad_arg'\")\n"
+      "ERROR:root:RubiconException(\"No project with name 'failure modes' found.\")\n"
      ]
     }
    ],
    "source": [
     "set_failure_mode(\"log\")\n",
     "\n",
-    "pr.log_experiment(bad_arg=None)"
+    "rb.get_project(name=\"failure modes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec648cde-0d9d-4d29-83f5-e58d090eb150",
+   "metadata": {},
+   "source": [
+    "text about setting back to \"raise\" for default behavior"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dca6c089-997c-4394-adbc-5629d91594c8",
+   "metadata": {},
+   "source": [
+    "### aside on return values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fd1815bf-3482-47a1-820c-ecfb5d82d6e2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Project(name='failure modes', id='1f71926a-8445-48bb-90b0-9a8a47fd2321', description=None, github_url=None, training_metadata=None, created_at=datetime.datetime(2022, 11, 15, 0, 41, 22, 738553))\n"
+     ]
+    }
+   ],
+   "source": [
+    "rb.create_project(name=\"failure modes\")\n",
+    "project = rb.get_project(name=\"failure modes\")\n",
+    "\n",
+    "print(project)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c603cc65-ca2f-4877-ae89-bde97420af34",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR:root:RubiconException(\"No project with name 'failure modes v2' found.\")\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "set_failure_mode(\"log\")\n",
+    "\n",
+    "project = rb.get_project(name=\"failure modes v2\")\n",
+    "print(project)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da65cc2f-711e-45df-a597-7bd834574ccd",
+   "metadata": {},
+   "source": [
+    "### more practical use"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1d4dd196-e640-4df8-8718-e4187e5cefe6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.neighbors import KNeighborsClassifier\n",
+    "\n",
+    "\n",
+    "class BrokenFilesystem:\n",
+    "    pass\n",
+    "\n",
+    "set_failure_mode(\"raise\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e76935dd-a711-4c30-b37a-a3a209410d30",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<rubicon_ml.client.experiment.Experiment at 0x16804ab00>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "project = rb.create_project(name=\"failure modes v3\")\n",
+    "experiment = project.log_experiment()\n",
+    "\n",
+    "experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "97952405-95b8-446f-a5f6-1d868d56aa1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rb.config.repository.filesystem = BrokenFilesystem()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "191b15c8-0497-4b36-87cd-893c36cf6252",
+   "id": "7cac1030-71d2-4c57-a76b-16d50778ee06",
    "metadata": {},
    "outputs": [
     {
-     "ename": "ValueError",
-     "evalue": "`failure_mode` must be one of ['log', 'raise', 'warn']",
+     "ename": "AttributeError",
+     "evalue": "'BrokenFilesystem' object has no attribute 'exists'",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn [9], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mset_failure_mode\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mfail\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m      3\u001b[0m pr\u001b[38;5;241m.\u001b[39mlog_experiment(bad_arg\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m)\n",
-      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:11\u001b[0m, in \u001b[0;36mset_failure_mode\u001b[0;34m(failure_mode)\u001b[0m\n\u001b[1;32m      8\u001b[0m \u001b[38;5;28;01mglobal\u001b[39;00m FAILURE_MODE\n\u001b[1;32m     10\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m failure_mode \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m FAILURE_MODES:\n\u001b[0;32m---> 11\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m`failure_mode` must be one of \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mFAILURE_MODES\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m     13\u001b[0m FAILURE_MODE \u001b[38;5;241m=\u001b[39m failure_mode\n",
-      "\u001b[0;31mValueError\u001b[0m: `failure_mode` must be one of ['log', 'raise', 'warn']"
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn [9], line 5\u001b[0m\n\u001b[1;32m      2\u001b[0m X_train, y_train, X_test, y_test \u001b[38;5;241m=\u001b[39m [[\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m3\u001b[39m]], [\u001b[38;5;241m0\u001b[39m], [[\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m3\u001b[39m]], [\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m      4\u001b[0m knn\u001b[38;5;241m.\u001b[39mfit(X_train, y_train)\n\u001b[0;32m----> 5\u001b[0m \u001b[43mexperiment\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlog_parameter\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mn_neighbors\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mvalue\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m1\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m      7\u001b[0m score \u001b[38;5;241m=\u001b[39m knn\u001b[38;5;241m.\u001b[39mscore(X_test, y_test)\n\u001b[1;32m      8\u001b[0m experiment\u001b[38;5;241m.\u001b[39mlog_metric(name\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mscore\u001b[39m\u001b[38;5;124m\"\u001b[39m, value\u001b[38;5;241m=\u001b[39mscore)\n",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:23\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     21\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     22\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[0;32m---> 23\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m e\n\u001b[1;32m     24\u001b[0m     \u001b[38;5;28;01melif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mwarn\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[1;32m     25\u001b[0m         warnings\u001b[38;5;241m.\u001b[39mwarn(\u001b[38;5;28mrepr\u001b[39m(e))\n",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:20\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     18\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mwrapper\u001b[39m(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m     19\u001b[0m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m---> 20\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     21\u001b[0m     \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     22\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/experiment.py:237\u001b[0m, in \u001b[0;36mExperiment.log_parameter\u001b[0;34m(self, name, value, description, tags)\u001b[0m\n\u001b[1;32m    214\u001b[0m \u001b[38;5;124;03m\"\"\"Create a parameter under the experiment.\u001b[39;00m\n\u001b[1;32m    215\u001b[0m \n\u001b[1;32m    216\u001b[0m \u001b[38;5;124;03mParameters\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    234\u001b[0m \u001b[38;5;124;03m    The created parameter.\u001b[39;00m\n\u001b[1;32m    235\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    236\u001b[0m parameter \u001b[38;5;241m=\u001b[39m domain\u001b[38;5;241m.\u001b[39mParameter(name, value\u001b[38;5;241m=\u001b[39mvalue, description\u001b[38;5;241m=\u001b[39mdescription, tags\u001b[38;5;241m=\u001b[39mtags)\n\u001b[0;32m--> 237\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrepository\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcreate_parameter\u001b[49m\u001b[43m(\u001b[49m\u001b[43mparameter\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mproject\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mname\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mid\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    239\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m Parameter(parameter, \u001b[38;5;28mself\u001b[39m)\n",
+      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/repository/base.py:852\u001b[0m, in \u001b[0;36mBaseRepository.create_parameter\u001b[0;34m(self, parameter, project_name, experiment_id)\u001b[0m\n\u001b[1;32m    836\u001b[0m \u001b[38;5;124;03m\"\"\"Persist a parameter to the configured filesystem.\u001b[39;00m\n\u001b[1;32m    837\u001b[0m \n\u001b[1;32m    838\u001b[0m \u001b[38;5;124;03mParameters\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    846\u001b[0m \u001b[38;5;124;03m    The ID of the experiment this parameter belongs to.\u001b[39;00m\n\u001b[1;32m    847\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    848\u001b[0m parameter_metadata_path \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_get_parameter_metadata_path(\n\u001b[1;32m    849\u001b[0m     project_name, experiment_id, parameter\u001b[38;5;241m.\u001b[39mname\n\u001b[1;32m    850\u001b[0m )\n\u001b[0;32m--> 852\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfilesystem\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexists\u001b[49m(parameter_metadata_path):\n\u001b[1;32m    853\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m RubiconException(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mA parameter with name \u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mparameter\u001b[38;5;241m.\u001b[39mname\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m already exists.\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    855\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_persist_domain(parameter, parameter_metadata_path)\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'BrokenFilesystem' object has no attribute 'exists'"
      ]
     }
    ],
    "source": [
-    "set_failure_mode(\"fail\")\n",
+    "knn = KNeighborsClassifier(n_neighbors=1)\n",
+    "X_train, y_train, X_test, y_test = [[0, 1, 2, 3]], [0], [[0, 1, 2, 3]], [0]\n",
     "\n",
-    "pr.log_experiment(bad_arg=None)"
+    "knn.fit(X_train, y_train)\n",
+    "experiment.log_parameter(name=\"n_neighbors\", value=1)\n",
+    "\n",
+    "score = knn.score(X_test, y_test)\n",
+    "experiment.log_metric(name=\"score\", value=score)\n",
+    "\n",
+    "score"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "23ab6659-812e-4246-a4cf-48743af5c9e4",
+   "id": "2c2556ce-e11f-4173-9e3a-f041dda56e98",
    "metadata": {},
    "outputs": [
     {
-     "ename": "ValueError",
-     "evalue": "`failure_mode` must be one of ['log', 'raise', 'warn']",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn [10], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mset_failure_mode\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:11\u001b[0m, in \u001b[0;36mset_failure_mode\u001b[0;34m(failure_mode)\u001b[0m\n\u001b[1;32m      8\u001b[0m \u001b[38;5;28;01mglobal\u001b[39;00m FAILURE_MODE\n\u001b[1;32m     10\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m failure_mode \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m FAILURE_MODES:\n\u001b[0;32m---> 11\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m`failure_mode` must be one of \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mFAILURE_MODES\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m     13\u001b[0m FAILURE_MODE \u001b[38;5;241m=\u001b[39m failure_mode\n",
-      "\u001b[0;31mValueError\u001b[0m: `failure_mode` must be one of ['log', 'raise', 'warn']"
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR:root:AttributeError(\"'BrokenFilesystem' object has no attribute 'exists'\")\n",
+      "ERROR:root:AttributeError(\"'BrokenFilesystem' object has no attribute 'exists'\")\n"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "1.0"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "set_failure_mode(None)"
+    "set_failure_mode(\"log\")\n",
+    "\n",
+    "knn = KNeighborsClassifier(n_neighbors=1)\n",
+    "X_train, y_train, X_test, y_test = [[0, 1, 2, 3]], [0], [[0, 1, 2, 3]], [0]\n",
+    "\n",
+    "knn.fit(X_train, y_train)\n",
+    "experiment.log_parameter(name=\"n_neighbors\", value=1)\n",
+    "\n",
+    "score = knn.score(X_test, y_test)\n",
+    "experiment.log_metric(name=\"score\", value=score)\n",
+    "\n",
+    "score"
    ]
   }
  ],

--- a/notebooks/tutorials/failure-modes.ipynb
+++ b/notebooks/tutorials/failure-modes.ipynb
@@ -5,7 +5,15 @@
    "id": "7de3eb73-75e0-43b3-887e-329773a72bf0",
    "metadata": {},
    "source": [
-    "# Failure Modes"
+    "# Ignoring Exceptions with Failure Modes\n",
+    "\n",
+    "`rubicon-ml` is often used for logging in scenarios that require high availability, like model inference pipelines\n",
+    "running in production environments. If something were to go wrong with `rubicon-ml` during live model inference,\n",
+    "we could end up halting predictions just for a logging issue. `rubicon-ml`'s configurable failure modes allow users\n",
+    "to choose what to do with `rubicon-ml` exceptions!\n",
+    "\n",
+    "First, let's try to get a project that we haven't yet created. This will show the default failure behavior - raising\n",
+    "a `RubiconException` that halts execution of the code it originated from."
    ]
   },
   {
@@ -49,6 +57,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "3b1fb098-c7c3-4210-b7a1-c1ea5a0e4317",
+   "metadata": {},
+   "source": [
+    "But, let's say we're far more concerned with keeping our code running than we are with whether or\n",
+    "not our logs get logged.\n",
+    "\n",
+    "We can `set_failure_mode` to \"warn\" to instead raise warnings (via the builtin `warnings.warn`)\n",
+    "whenever `rubicon-ml` encounters an exception and continue execution of the offending code."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "457871b9-cb20-49b8-847e-bf563fbb255f",
@@ -78,6 +98,14 @@
     "set_failure_mode(\"warn\")\n",
     "\n",
     "rb.get_project(name=\"failure modes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd274187-68b4-4a2f-9734-aa84e2b77f87",
+   "metadata": {},
+   "source": [
+    "We can also `set_failure_mode` to \"log\" to log the error with the builtin `logging.error`."
    ]
   },
   {
@@ -113,9 +141,15 @@
    "id": "ec648cde-0d9d-4d29-83f5-e58d090eb150",
    "metadata": {},
    "source": [
-    "text about setting back to \"raise\" for default behavior\n",
+    "`set_failure_mode` back to the default - \"raise\" - to return to raising the exceptions.\n",
     "\n",
-    "### verbosity"
+    "## Log and warning verbosity\n",
+    "\n",
+    "The \"log\" and \"warn\" failure modes leverage the builtin `traceback.exc_info()` in order to print an error's\n",
+    "traceback. `set_failure_mode`'s `traceback_limit` and `traceback_chain` are passed directly through to the\n",
+    "underlying call to `traceback.exc_info()` as the `limit` and `chain` arguments.\n",
+    "\n",
+    "`limit` is an integer between 0 and the depth of the stack trace that controls the verbosity of the trace."
    ]
   },
   {
@@ -137,6 +171,15 @@
     "set_failure_mode(\"log\", traceback_limit=0)\n",
     "\n",
     "rb.get_project(name=\"failure modes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd12b2c0-6873-4f44-b751-58c572dbbfd8",
+   "metadata": {},
+   "source": [
+    "`chain` can be set to `True` to see the full chain of exceptions rather than just the final exception in the\n",
+    "chain."
    ]
   },
   {
@@ -190,7 +233,11 @@
    "id": "dca6c089-997c-4394-adbc-5629d91594c8",
    "metadata": {},
    "source": [
-    "### aside on return values"
+    "## Caution with return values\n",
+    "\n",
+    "Some workflows require the returned `rubicon-ml` objects to be leveraged for future logging in the\n",
+    "same process. For example, let's finally create the \"failure modes\" project and take a look at the\n",
+    "returned `rubicon-ml` object."
    ]
   },
   {
@@ -203,7 +250,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Project(name='failure modes', id='1790ba2e-363f-4982-bf98-a117d1474826', description=None, github_url=None, training_metadata=None, created_at=datetime.datetime(2022, 11, 15, 14, 26, 27, 485224))\n"
+      "Project(name='failure modes', id='ddef2b43-cdc0-4ebf-93a9-26bd93bf1f42', description=None, github_url=None, training_metadata=None, created_at=datetime.datetime(2022, 11, 15, 16, 3, 40, 999293))\n"
      ]
     }
    ],
@@ -215,8 +262,48 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6b96df86-9926-4d2c-bcd0-55c9288a0623",
+   "metadata": {},
+   "source": [
+    "Now we can take any standard action on the returned `rubicon-ml` object, like inspecting its ID."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "76ebe66a-cb47-4de5-9cae-4cab134c0050",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ddef2b43-cdc0-4ebf-93a9-26bd93bf1f42\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(project.id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "026f68bf-1709-46d3-96dc-d4206cb9bbc9",
+   "metadata": {},
+   "source": [
+    "If we were to leverage either the \"log\" or \"warn\" failure mode, which does not stop execution for `rubicon-ml`\n",
+    "errors, we need to be cautious of returned `rubicon-ml` objects.\n",
+    "\n",
+    "Now we'll try to get another project that doesn't exist. Even though this code will not stop execution after the\n",
+    "failed `get_project` call, we need to be aware that a `rubicon-ml` project **will not be returned in this case**.\n",
+    "A `None` will be returned in its place, thus any action taken on this returned `None` may fail if only `rubicon-ml`\n",
+    "objects are expected downstream."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "id": "c603cc65-ca2f-4877-ae89-bde97420af34",
    "metadata": {},
    "outputs": [
@@ -252,41 +339,52 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da65cc2f-711e-45df-a597-7bd834574ccd",
+   "id": "5d637dec-3725-4df5-aa1c-e0e08c2b45a9",
    "metadata": {},
    "source": [
-    "### more practical use"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "1d4dd196-e640-4df8-8718-e4187e5cefe6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.neighbors import KNeighborsClassifier\n",
-    "\n",
-    "\n",
-    "class BrokenFilesystem:\n",
-    "    pass\n",
-    "\n",
-    "set_failure_mode(\"raise\")"
+    "When leveraging failure modes that do not interrupt execution, it is important to check the types of the objects\n",
+    "returned from `rubicon-ml`. Simply trying to access the `id` attribute in this case would result in an `AttributeError`\n",
+    "as a `NoneType` object hs no attribute `id`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
+   "id": "5d9e7a53-b30e-4941-8657-3a9f338194a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if project is not None:\n",
+    "    print(project.id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da65cc2f-711e-45df-a597-7bd834574ccd",
+   "metadata": {},
+   "source": [
+    "## A more practical use case\n",
+    "\n",
+    "Let's take a look at how this may work in a more practical machine learning workflow. For\n",
+    "this example, we'll train a k-neighbors classifier from Scikit-learn and attempt to log\n",
+    "the input parameters and the score the trained model produces on a test dataset.\n",
+    "\n",
+    "First, we'll create a new project and experiment to attempt to log our inputs and outputs to."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
    "id": "e76935dd-a711-4c30-b37a-a3a209410d30",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<rubicon_ml.client.experiment.Experiment at 0x164326f80>"
+       "<rubicon_ml.client.experiment.Experiment at 0x16055e320>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -299,18 +397,46 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "97952405-95b8-446f-a5f6-1d868d56aa1f",
+   "cell_type": "markdown",
+   "id": "06c4e03a-dc2c-4b06-a90c-8369e5eecc48",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "rb.config.repository.filesystem = BrokenFilesystem()"
+    "Now that we've got an experiment, lets replace `rubicon-ml`'s `filesystem` (the part\n",
+    "of the library that handles actual filesystem operations) with a no-op class representing\n",
+    "a broken filesystem. Imagine this simulating something like losing connection to S3.\n",
+    "\n",
+    "We'll also set the failure mode back to raise for this first execution of our workflow\n",
+    "with the broken filesystem."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
+   "id": "1d4dd196-e640-4df8-8718-e4187e5cefe6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class BrokenFilesystem:\n",
+    "    pass\n",
+    "\n",
+    "rb.config.repository.filesystem = BrokenFilesystem()\n",
+    "\n",
+    "set_failure_mode(\"raise\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fea9d4cc-1e51-4aec-8fb2-222c55b59a2c",
+   "metadata": {},
+   "source": [
+    "Now, notice that when we run the cell below, we only fit the model before execution is halted due\n",
+    "to `experiment.log_parameter` raising an exception because of the broken filesystem. We never get\n",
+    "a `score`, and it is never displayed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
    "id": "7cac1030-71d2-4c57-a76b-16d50778ee06",
    "metadata": {},
    "outputs": [
@@ -321,7 +447,7 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn [11], line 5\u001b[0m\n\u001b[1;32m      2\u001b[0m X_train, y_train, X_test, y_test \u001b[38;5;241m=\u001b[39m [[\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m3\u001b[39m]], [\u001b[38;5;241m0\u001b[39m], [[\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m3\u001b[39m]], [\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m      4\u001b[0m knn\u001b[38;5;241m.\u001b[39mfit(X_train, y_train)\n\u001b[0;32m----> 5\u001b[0m \u001b[43mexperiment\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlog_parameter\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mn_neighbors\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mvalue\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m1\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m      7\u001b[0m score \u001b[38;5;241m=\u001b[39m knn\u001b[38;5;241m.\u001b[39mscore(X_test, y_test)\n\u001b[1;32m      8\u001b[0m experiment\u001b[38;5;241m.\u001b[39mlog_metric(name\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mscore\u001b[39m\u001b[38;5;124m\"\u001b[39m, value\u001b[38;5;241m=\u001b[39mscore)\n",
+      "Cell \u001b[0;32mIn [12], line 8\u001b[0m\n\u001b[1;32m      5\u001b[0m X_train, y_train, X_test, y_test \u001b[38;5;241m=\u001b[39m [[\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m3\u001b[39m]], [\u001b[38;5;241m0\u001b[39m], [[\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m3\u001b[39m]], [\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m      7\u001b[0m knn\u001b[38;5;241m.\u001b[39mfit(X_train, y_train)\n\u001b[0;32m----> 8\u001b[0m \u001b[43mexperiment\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlog_parameter\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mn_neighbors\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mvalue\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m1\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m     10\u001b[0m score \u001b[38;5;241m=\u001b[39m knn\u001b[38;5;241m.\u001b[39mscore(X_test, y_test)\n\u001b[1;32m     11\u001b[0m experiment\u001b[38;5;241m.\u001b[39mlog_metric(name\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mscore\u001b[39m\u001b[38;5;124m\"\u001b[39m, value\u001b[38;5;241m=\u001b[39mscore)\n",
       "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:30\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     28\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     29\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[0;32m---> 30\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m e\n\u001b[1;32m     31\u001b[0m     \u001b[38;5;28;01melif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mwarn\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[1;32m     32\u001b[0m         warnings\u001b[38;5;241m.\u001b[39mwarn(traceback\u001b[38;5;241m.\u001b[39mformat_exc(limit\u001b[38;5;241m=\u001b[39mTRACEBACK_LIMIT, chain\u001b[38;5;241m=\u001b[39mTRACEBACK_CHAIN))\n",
       "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/utils/exception_handling.py:27\u001b[0m, in \u001b[0;36mfailsafe.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     25\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mwrapper\u001b[39m(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[1;32m     26\u001b[0m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m---> 27\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     28\u001b[0m     \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m     29\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m FAILURE_MODE \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mraise\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n",
       "File \u001b[0;32m~/github/capitalone/rubicon-ml/rubicon_ml/client/experiment.py:237\u001b[0m, in \u001b[0;36mExperiment.log_parameter\u001b[0;34m(self, name, value, description, tags)\u001b[0m\n\u001b[1;32m    214\u001b[0m \u001b[38;5;124;03m\"\"\"Create a parameter under the experiment.\u001b[39;00m\n\u001b[1;32m    215\u001b[0m \n\u001b[1;32m    216\u001b[0m \u001b[38;5;124;03mParameters\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    234\u001b[0m \u001b[38;5;124;03m    The created parameter.\u001b[39;00m\n\u001b[1;32m    235\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    236\u001b[0m parameter \u001b[38;5;241m=\u001b[39m domain\u001b[38;5;241m.\u001b[39mParameter(name, value\u001b[38;5;241m=\u001b[39mvalue, description\u001b[38;5;241m=\u001b[39mdescription, tags\u001b[38;5;241m=\u001b[39mtags)\n\u001b[0;32m--> 237\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrepository\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcreate_parameter\u001b[49m\u001b[43m(\u001b[49m\u001b[43mparameter\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mproject\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mname\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mid\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    239\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m Parameter(parameter, \u001b[38;5;28mself\u001b[39m)\n",
@@ -331,6 +457,9 @@
     }
    ],
    "source": [
+    "from sklearn.neighbors import KNeighborsClassifier\n",
+    "\n",
+    "\n",
     "knn = KNeighborsClassifier(n_neighbors=1)\n",
     "X_train, y_train, X_test, y_test = [[0, 1, 2, 3]], [0], [[0, 1, 2, 3]], [0]\n",
     "\n",
@@ -344,8 +473,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "28669f56-aaae-4112-b284-e4f51f5c56e1",
+   "metadata": {},
+   "source": [
+    "By setting the failure mode to \"log\" and ensuring we are not using any unchecked objects returned\n",
+    "by `rubicon-ml`, we can ensure that the entire workflow is completed regardless of whether or not\n",
+    "the filesystem is working."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "2c2556ce-e11f-4173-9e3a-f041dda56e98",
    "metadata": {},
    "outputs": [
@@ -379,7 +518,7 @@
        "1.0"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/rubicon_ml/__init__.py
+++ b/rubicon_ml/__init__.py
@@ -13,6 +13,7 @@ from rubicon_ml.client import (  # noqa: E402
     Project,
     Rubicon,
 )
+from rubicon_ml.client.utils.exception_handling import set_failure_mode  # noqa: E402
 from rubicon_ml.intake_rubicon.publish import publish  # noqa: E402
 
 __all__ = [
@@ -25,4 +26,5 @@ __all__ = [
     "Project",
     "publish",
     "Rubicon",
+    "set_failure_mode",
 ]

--- a/rubicon_ml/client/artifact.py
+++ b/rubicon_ml/client/artifact.py
@@ -4,6 +4,7 @@ import fsspec
 
 from rubicon_ml.client.base import Base
 from rubicon_ml.client.mixin import TagMixin
+from rubicon_ml.client.utils.exception_handling import failsafe
 
 
 class Artifact(Base, TagMixin):
@@ -42,6 +43,7 @@ class Artifact(Base, TagMixin):
             project_name, self.id, experiment_id=experiment_id
         )
 
+    @failsafe
     def download(self, location=None, name=None):
         """Download this artifact's data.
 

--- a/rubicon_ml/client/dataframe.py
+++ b/rubicon_ml/client/dataframe.py
@@ -1,4 +1,5 @@
 from rubicon_ml.client import Base, TagMixin
+from rubicon_ml.client.utils.exception_handling import failsafe
 from rubicon_ml.exceptions import RubiconException
 
 
@@ -29,6 +30,7 @@ class Dataframe(Base, TagMixin):
         self._data = None
         self._parent = parent
 
+    @failsafe
     def get_data(self, df_type="pandas"):
         """Loads the data associated with this Dataframe
         into a `pandas` or `dask` dataframe.
@@ -50,6 +52,7 @@ class Dataframe(Base, TagMixin):
 
         return self._data
 
+    @failsafe
     def plot(self, df_type="pandas", plotting_func=None, **kwargs):
         """Render the dataframe using `plotly.express`.
 

--- a/rubicon_ml/client/experiment.py
+++ b/rubicon_ml/client/experiment.py
@@ -8,6 +8,7 @@ from rubicon_ml.client import (
     Parameter,
     TagMixin,
 )
+from rubicon_ml.client.utils.exception_handling import failsafe
 from rubicon_ml.client.utils.tags import filter_children
 
 
@@ -42,6 +43,7 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
         """Get the experiment's project's name and the experiment's ID."""
         return self.project.name, self.id
 
+    @failsafe
     def log_metric(self, name, value, directionality="score", description=None, tags=[]):
         """Create a metric under the experiment.
 
@@ -75,6 +77,7 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
 
         return Metric(metric, self)
 
+    @failsafe
     def metrics(self, name=None, tags=[], qtype="or"):
         """Get the metrics logged to this experiment.
 
@@ -98,6 +101,7 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
 
         return self._metrics
 
+    @failsafe
     def metric(self, name=None, id=None):
         """Get a metric.
 
@@ -124,6 +128,7 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
 
         return metric
 
+    @failsafe
     def log_feature(self, name, description=None, importance=None, tags=[]):
         """Create a feature under the experiment.
 
@@ -150,6 +155,7 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
 
         return Feature(feature, self)
 
+    @failsafe
     def features(self, name=None, tags=[], qtype="or"):
         """Get the features logged to this experiment.
 
@@ -176,6 +182,7 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
         self._features = filter_children(features, tags, qtype, name)
         return self._features
 
+    @failsafe
     def feature(self, name=None, id=None):
         """Get a feature.
 
@@ -202,6 +209,7 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
 
         return feature
 
+    @failsafe
     def log_parameter(self, name, value=None, description=None, tags=[]):
         """Create a parameter under the experiment.
 
@@ -230,6 +238,7 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
 
         return Parameter(parameter, self)
 
+    @failsafe
     def parameters(self, name=None, tags=[], qtype="or"):
         """Get the parameters logged to this experiment.
 
@@ -257,6 +266,7 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
 
         return self._parameters
 
+    @failsafe
     def parameter(self, name=None, id=None):
         """Get a parameter.
 

--- a/rubicon_ml/client/mixin.py
+++ b/rubicon_ml/client/mixin.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import fsspec
 
 from rubicon_ml import client, domain
+from rubicon_ml.client.utils.exception_handling import failsafe
 from rubicon_ml.client.utils.tags import filter_children
 from rubicon_ml.exceptions import RubiconException
 
@@ -39,6 +40,7 @@ class ArtifactMixin:
 
         return data_bytes, name
 
+    @failsafe
     def log_artifact(
         self,
         data_bytes=None,
@@ -135,6 +137,7 @@ class ArtifactMixin:
 
         return completed_process.stdout
 
+    @failsafe
     def log_conda_environment(self, artifact_name=None):
         """Log the conda environment as an artifact to this client object.
         Useful for recreating your exact environment at a later date.
@@ -161,6 +164,7 @@ class ArtifactMixin:
 
         return artifact
 
+    @failsafe
     def log_pip_requirements(self, artifact_name=None):
         """Log the pip requirements as an artifact to this client object.
         Useful for recreating your exact environment at a later date.
@@ -183,6 +187,7 @@ class ArtifactMixin:
 
         return artifact
 
+    @failsafe
     def artifacts(self, name=None, tags=[], qtype="or"):
         """Get the artifacts logged to this client object.
 
@@ -213,6 +218,7 @@ class ArtifactMixin:
 
         return self._artifacts
 
+    @failsafe
     def artifact(self, name=None, id=None):
         """Get an artifact logged to this project by id or name.
 
@@ -250,6 +256,7 @@ class ArtifactMixin:
 
         return artifact
 
+    @failsafe
     def delete_artifacts(self, ids):
         """Delete the artifacts logged to with client object
         with ids `ids`.
@@ -268,6 +275,7 @@ class ArtifactMixin:
 class DataframeMixin:
     """Adds dataframe support to a client object."""
 
+    @failsafe
     def log_dataframe(self, df, description=None, name=None, tags=[]):
         """Log a dataframe to this client object.
 
@@ -298,6 +306,7 @@ class DataframeMixin:
 
         return client.Dataframe(dataframe, self)
 
+    @failsafe
     def dataframes(self, name=None, tags=[], qtype="or"):
         """Get the dataframes logged to this client object.
 
@@ -328,6 +337,7 @@ class DataframeMixin:
 
         return self._dataframes
 
+    @failsafe
     def dataframe(self, name=None, id=None):
         """
         Get the dataframe logged to this client object.
@@ -369,6 +379,7 @@ class DataframeMixin:
 
         return dataframe
 
+    @failsafe
     def delete_dataframes(self, ids):
         """Delete the dataframes with ids `ids` logged to
         this client object.
@@ -405,6 +416,7 @@ class TagMixin:
 
         return project_name, experiment_id, entity_identifier
 
+    @failsafe
     def add_tags(self, tags):
         """Add tags to this client object.
 
@@ -424,6 +436,7 @@ class TagMixin:
             entity_type=self.__class__.__name__,
         )
 
+    @failsafe
     def remove_tags(self, tags):
         """Remove tags from this client object.
 

--- a/rubicon_ml/client/project.py
+++ b/rubicon_ml/client/project.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from rubicon_ml import domain
 from rubicon_ml.client import ArtifactMixin, Base, DataframeMixin, Experiment
+from rubicon_ml.client.utils.exception_handling import failsafe
 from rubicon_ml.client.utils.tags import filter_children
 from rubicon_ml.exceptions import RubiconException
 
@@ -193,6 +194,7 @@ class Project(Base, ArtifactMixin, DataframeMixin):
 
         return experiment_dfs if group_by is not None else list(experiment_dfs.values())[0]
 
+    @failsafe
     def log_experiment(
         self,
         name=None,

--- a/rubicon_ml/client/project.py
+++ b/rubicon_ml/client/project.py
@@ -120,6 +120,7 @@ class Project(Base, ArtifactMixin, DataframeMixin):
 
         return self.to_df(df_type="dask", group_by=group_by)
 
+    @failsafe
     def to_df(self, df_type="pandas", group_by=None):
         """Loads the project's data into dask or pandas dataframe(s) sorted by
         `created_at`. This includes the experiment details along with parameters
@@ -253,6 +254,7 @@ class Project(Base, ArtifactMixin, DataframeMixin):
 
         return Experiment(experiment, self)
 
+    @failsafe
     def experiment(self, id=None, name=None):
         """Get an experiment logged to this project by id or name.
 
@@ -288,6 +290,7 @@ class Project(Base, ArtifactMixin, DataframeMixin):
 
         return experiment
 
+    @failsafe
     def experiments(self, tags=[], qtype="or", name=None):
         """Get the experiments logged to this project.
 
@@ -311,6 +314,7 @@ class Project(Base, ArtifactMixin, DataframeMixin):
 
         return self._experiments
 
+    @failsafe
     def dataframes(self, tags=[], qtype="or", recursive=False, name=None):
         """Get the dataframes logged to this project.
 

--- a/rubicon_ml/client/rubicon.py
+++ b/rubicon_ml/client/rubicon.py
@@ -3,6 +3,7 @@ import warnings
 
 from rubicon_ml import domain
 from rubicon_ml.client import Config, Project
+from rubicon_ml.client.utils.exception_handling import failsafe
 from rubicon_ml.exceptions import RubiconException
 from rubicon_ml.repository.utils import slugify
 
@@ -71,6 +72,7 @@ class Rubicon:
             training_metadata=training_metadata,
         )
 
+    @failsafe
     def create_project(self, name, description=None, github_url=None, training_metadata=None):
         """Create a project.
 
@@ -98,6 +100,7 @@ class Rubicon:
 
         return Project(project, self.config)
 
+    @failsafe
     def get_project(self, name=None, id=None):
         """Get a project.
 
@@ -134,6 +137,7 @@ class Rubicon:
 
         return self.get_project_as_df(name, df_type="dask", group_by=group_by)
 
+    @failsafe
     def get_project_as_df(self, name, df_type="pandas", group_by=None):
         """Get a dask or pandas dataframe representation of a project.
 
@@ -159,6 +163,7 @@ class Rubicon:
 
         return project.to_df(df_type=df_type, group_by=None)
 
+    @failsafe
     def get_or_create_project(self, name, **kwargs):
         """Get or create a project.
 
@@ -182,6 +187,7 @@ class Rubicon:
 
         return project
 
+    @failsafe
     def projects(self):
         """Get a list of available projects.
 
@@ -192,6 +198,7 @@ class Rubicon:
         """
         return [Project(project, self.config) for project in self.repository.get_projects()]
 
+    @failsafe
     def sync(self, project_name, s3_root_dir):
         """Sync a local project to S3.
 

--- a/rubicon_ml/client/rubicon.py
+++ b/rubicon_ml/client/rubicon.py
@@ -184,6 +184,9 @@ class Rubicon:
             project = self.get_project(name)
         except RubiconException:
             project = self.create_project(name, **kwargs)
+        else:  # check for None in case of failure mode being set to "log" or "warn"
+            if project is None:
+                project = self.create_project(name, **kwargs)
 
         return project
 

--- a/rubicon_ml/client/utils/exception_handling.py
+++ b/rubicon_ml/client/utils/exception_handling.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import traceback
 import warnings
@@ -38,6 +39,7 @@ def set_failure_mode(failure_mode, traceback_chain=False, traceback_limit=None):
 
 
 def failsafe(func):
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)

--- a/rubicon_ml/client/utils/exception_handling.py
+++ b/rubicon_ml/client/utils/exception_handling.py
@@ -1,0 +1,29 @@
+import logging
+import warnings
+
+FAILURE_MODE = "raise"
+FAILURE_MODES = ["log", "raise", "warn"]
+
+
+def set_failure_mode(failure_mode):
+    global FAILURE_MODE
+
+    if failure_mode not in FAILURE_MODES:
+        raise ValueError(f"`failure_mode` must be one of {FAILURE_MODES}")
+
+    FAILURE_MODE = failure_mode
+
+
+def failsafe(func):
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            if FAILURE_MODE == "raise":
+                raise e
+            elif FAILURE_MODE == "warn":
+                warnings.warn(repr(e))
+            elif FAILURE_MODE == "log":
+                logging.error(repr(e))
+
+    return wrapper

--- a/rubicon_ml/client/utils/exception_handling.py
+++ b/rubicon_ml/client/utils/exception_handling.py
@@ -1,17 +1,24 @@
 import logging
+import traceback
 import warnings
 
 FAILURE_MODE = "raise"
 FAILURE_MODES = ["log", "raise", "warn"]
+TRACEBACK_CHAIN = False
+TRACEBACK_LIMIT = None
 
 
-def set_failure_mode(failure_mode):
+def set_failure_mode(failure_mode, traceback_chain=False, traceback_limit=None):
     global FAILURE_MODE
+    global TRACEBACK_CHAIN
+    global TRACEBACK_LIMIT
 
     if failure_mode not in FAILURE_MODES:
         raise ValueError(f"`failure_mode` must be one of {FAILURE_MODES}")
 
     FAILURE_MODE = failure_mode
+    TRACEBACK_CHAIN = traceback_chain
+    TRACEBACK_LIMIT = traceback_limit
 
 
 def failsafe(func):
@@ -22,8 +29,8 @@ def failsafe(func):
             if FAILURE_MODE == "raise":
                 raise e
             elif FAILURE_MODE == "warn":
-                warnings.warn(repr(e))
+                warnings.warn(traceback.format_exc(limit=TRACEBACK_LIMIT, chain=TRACEBACK_CHAIN))
             elif FAILURE_MODE == "log":
-                logging.error(repr(e))
+                logging.error(traceback.format_exc(limit=TRACEBACK_LIMIT, chain=TRACEBACK_CHAIN))
 
     return wrapper

--- a/rubicon_ml/client/utils/exception_handling.py
+++ b/rubicon_ml/client/utils/exception_handling.py
@@ -9,6 +9,22 @@ TRACEBACK_LIMIT = None
 
 
 def set_failure_mode(failure_mode, traceback_chain=False, traceback_limit=None):
+    """Set the failure mode.
+
+    Parameters
+    ----------
+    failure_mode : str
+        The name of the failure mode to set. "raise" to raise all exceptions,
+        "log" to catch all exceptions and log them via `logging.error`, "warn"
+        to catch all exceptions and re-raise them as warnings via `warnings.warn`.
+        Defaults to "raise".
+    traceback_chain : bool, optional
+        True to display each error in the traceback chain when logging or warning,
+        False to display only the first. Defaults to False.
+    traceback_limit : int, optional
+        The depth of the traceback displayed when logging or warning. 0 to display
+        only the error's text, each increment shows another line of the traceback.
+    """
     global FAILURE_MODE
     global TRACEBACK_CHAIN
     global TRACEBACK_LIMIT

--- a/tests/notebooks/test_notebooks.py
+++ b/tests/notebooks/test_notebooks.py
@@ -51,6 +51,7 @@ def test_notebook_is_executed_in_order(notebook_filename):
 
 IGNORE_EXECUTE_NOTEBOOK_FILENAMES = [
     "classification.ipynb",
+    "failure-modes.ipynb",
     "integration-prefect-workflows.ipynb",
     "visualizing-experiments.ipynb",
 ]

--- a/tests/unit/client/utils/test_exception_handling.py
+++ b/tests/unit/client/utils/test_exception_handling.py
@@ -14,6 +14,9 @@ def test_set_failure_mode(failure_mode):
 
     assert FAILURE_MODE == failure_mode
 
+    # cleanup: reset to default
+    set_failure_mode("raise")
+
 
 def test_set_failure_mode_traceback_options():
     traceback_chain = True
@@ -54,6 +57,9 @@ def test_failure_mode_log(mock_warn, rubicon_client):
 
     mock_warn.assert_called_once()
 
+    # cleanup: reset to default
+    set_failure_mode("raise")
+
 
 @patch("logging.error")
 def test_failure_mode_warn(mock_logger, rubicon_client):
@@ -62,3 +68,6 @@ def test_failure_mode_warn(mock_logger, rubicon_client):
     rubicon_client.get_project(name="does not exist")
 
     mock_logger.assert_called_once()
+
+    # cleanup: reset to default
+    set_failure_mode("raise")

--- a/tests/unit/client/utils/test_exception_handling.py
+++ b/tests/unit/client/utils/test_exception_handling.py
@@ -1,0 +1,64 @@
+from unittest.mock import patch
+
+import pytest
+
+from rubicon_ml.client.utils.exception_handling import FAILURE_MODES, set_failure_mode
+from rubicon_ml.exceptions import RubiconException
+
+
+@pytest.mark.parametrize("failure_mode", FAILURE_MODES)
+def test_set_failure_mode(failure_mode):
+    set_failure_mode(failure_mode=failure_mode)
+
+    from rubicon_ml.client.utils.exception_handling import FAILURE_MODE
+
+    assert FAILURE_MODE == failure_mode
+
+
+def test_set_failure_mode_traceback_options():
+    traceback_chain = True
+    traceback_limit = 1
+
+    set_failure_mode("raise", traceback_chain=traceback_chain, traceback_limit=traceback_limit)
+
+    from rubicon_ml.client.utils.exception_handling import (
+        TRACEBACK_CHAIN,
+        TRACEBACK_LIMIT,
+    )
+
+    assert TRACEBACK_CHAIN == traceback_chain
+    assert TRACEBACK_LIMIT == traceback_limit
+
+
+def test_set_failure_mode_error():
+    with pytest.raises(ValueError) as e:
+        set_failure_mode("invalid mode")
+
+    assert f"`failure_mode` must be one of {FAILURE_MODES}" in repr(e)
+
+
+def test_failure_mode_raise(rubicon_client):
+    set_failure_mode("raise")
+
+    with pytest.raises(RubiconException) as e:
+        rubicon_client.get_project(name="does not exist")
+
+    assert "No project with name 'does not exist' found." in repr(e)
+
+
+@patch("warnings.warn")
+def test_failure_mode_log(mock_warn, rubicon_client):
+    set_failure_mode("warn")
+
+    rubicon_client.get_project(name="does not exist")
+
+    mock_warn.assert_called_once()
+
+
+@patch("logging.error")
+def test_failure_mode_warn(mock_logger, rubicon_client):
+    set_failure_mode("log")
+
+    rubicon_client.get_project(name="does not exist")
+
+    mock_logger.assert_called_once()


### PR DESCRIPTION
## What
  * adds failure modes to rubicon to log or warn on exceptions rather than raising them
    * adds `set_failure_mode` and the `failsafe` decorator to `rubicon_ml.client.utils.exception_handling`
    * decorates each public facing client method with `@failsafe`
  * adds example to docs
    * adds new tutorial section to docs' source
      * TODO (future): reorganize these source files to match the structure of the rendered docs

## How to Test
  * run through the new example, `notebooks/tutorials/failure-modes.ipynb`, and make sure it works as expected
  * build the docs locally and validate that the new example renders properly and the new `exception_handling` module is present in the API reference
