### PR TITLE
Tagging Bug Fix

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,7 @@ dependencies:
   - flake8
   - ipykernel
   - isort
+  - jupyterlab
   - nbconvert
   - pytest
   - pytest-cov

--- a/rubicon_ml/client/experiment.py
+++ b/rubicon_ml/client/experiment.py
@@ -70,6 +70,9 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
         rubicon.client.Metric
             The created metric.
         """
+        if not isinstance(tags, list) or not all([isinstance(tag, str) for tag in tags]):
+            raise ValueError("`tags` must be `list` of type `str`")
+
         metric = domain.Metric(
             name, value, directionality=directionality, description=description, tags=tags
         )
@@ -150,6 +153,9 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
         rubicon.client.Feature
             The created feature.
         """
+        if not isinstance(tags, list) or not all([isinstance(tag, str) for tag in tags]):
+            raise ValueError("`tags` must be `list` of type `str`")
+
         feature = domain.Feature(name, description=description, importance=importance, tags=tags)
         self.repository.create_feature(feature, self.project.name, self.id)
 
@@ -233,6 +239,9 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
         rubicon.client.Parameter
             The created parameter.
         """
+        if not isinstance(tags, list) or not all([isinstance(tag, str) for tag in tags]):
+            raise ValueError("`tags` must be `list` of type `str`")
+
         parameter = domain.Parameter(name, value=value, description=description, tags=tags)
         self.repository.create_parameter(parameter, self.project.name, self.id)
 

--- a/rubicon_ml/client/mixin.py
+++ b/rubicon_ml/client/mixin.py
@@ -101,6 +101,9 @@ class ArtifactMixin:
         ...     data_path="./path/to/artifact.pkl", description="log artifact from file path"
         ... )
         """
+        if not isinstance(tags, list) or not all([isinstance(tag, str) for tag in tags]):
+            raise ValueError("`tags` must be `list` of type `str`")
+
         data_bytes, name = self._validate_data(data_bytes, data_file, data_path, name)
 
         artifact = domain.Artifact(
@@ -294,6 +297,9 @@ class DataframeMixin:
         rubicon.client.Dataframe
             The new dataframe.
         """
+        if not isinstance(tags, list) or not all([isinstance(tag, str) for tag in tags]):
+            raise ValueError("`tags` must be `list` of type `str`")
+
         dataframe = domain.Dataframe(
             parent_id=self._domain.id,
             description=description,
@@ -425,6 +431,9 @@ class TagMixin:
         tags : list of str
             The tag values to add.
         """
+        if not isinstance(tags, list) or not all([isinstance(tag, str) for tag in tags]):
+            raise ValueError("`tags` must be `list` of type `str`")
+
         project_name, experiment_id, entity_identifier = self._get_taggable_identifiers()
 
         self._domain.add_tags(tags)

--- a/rubicon_ml/client/project.py
+++ b/rubicon_ml/client/project.py
@@ -241,6 +241,9 @@ class Project(Base, ArtifactMixin, DataframeMixin):
         rubicon.client.Experiment
             The created experiment.
         """
+        if not isinstance(tags, list) or not all([isinstance(tag, str) for tag in tags]):
+            raise ValueError("`tags` must be `list` of type `str`")
+
         experiment = self._create_experiment_domain(
             name,
             description,


### PR DESCRIPTION
closes: #302

---

## What
  * Adds type checking to `tags` argument whenever logging artifacts, dataframes, experiments, features, metrics, or parameters as well as whenever adding tags to these objects to make sure `tags` is a `list` of type `str`
  * Makes sure every `tag` in `tags` is of type `str`
  * Also adds jupyterlab to environment for testing purposes

## How to Test
```
from rubicon_ml import Rubicon

rb = Rubicon(persistence="memory")
pr = rb.create_project(name="tag bug")

//Will raise ValueError
ex = pr.log_experiment(tags="tags")
//Will raise ValueError
ex = pr.log_experiment(tags=["tags", 2])

ex = pr.log_experiment(tags=["tag1", "tag2"])

//Will raise ValueError
ex.add_tags("tags")
//Will raise ValueError
ex.add_tags(["tags", 2])

ex.add_tags(["tag3", "tag4"])

