### PR TITLE
Log python objects as artifacts

### DIFF
--- a/rubicon_ml/client/artifact.py
+++ b/rubicon_ml/client/artifact.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 
 import fsspec
 
@@ -42,6 +43,24 @@ class Artifact(Base, TagMixin):
         self._data = self.repository.get_artifact_data(
             project_name, self.id, experiment_id=experiment_id
         )
+
+    def get_data(self, unpickle=False):
+        """Loads the data associated with this artifact and
+        unpickles if needed.
+
+        Parameters
+        ----------
+        unpickle : bool, optional
+            Flag indicating whether artifact data must be
+            unpickled. Will be returned as bytes by default.
+        """
+        project_name, experiment_id = self.parent._get_identifiers()
+
+        data = self.repository.get_artifact_data(project_name, self.id, experiment_id=experiment_id)
+        if unpickle:
+            data = pickle.loads(data)
+
+        return data
 
     @failsafe
     def download(self, location=None, name=None):


### PR DESCRIPTION
closes: #303

---

## What
  * Allows users to pass in python objects to `log_artifact()`
  * Pickles the data internally
  * Can retrieve unpickled data by calling `get_data(unpickled=True)` on logged artifact

## How to Test
```
>>> from rubicon_ml import Rubicon
>>> rb = Rubicon(persistence="memory")
>>> pr = rb.create_project(name="python artifacts")
>>> class ExampleObject:
...     value = 3
... 
>>> noname_object = ExampleObject()
>>> ar = pr.log_artifact(data_object=noname_object) #Errors

>>> class ExampleObjectWithName:
...     value = 3
...     name = "test"
... 
>>> named_object = ExampleObjectWithName()
>>> ar = pr.log_artifact(data_object=named_object)
>>> ar.get_data(unpickle=True)
<__main__.ExampleObjectWithName object at 0x15218ddb0>
```