### PR TITLE
Update logging_experiments notebook with python object artifact logging

### DIFF
--- a/notebooks/quick-look/logging-experiments.ipynb
+++ b/notebooks/quick-look/logging-experiments.ipynb
@@ -661,14 +661,13 @@
     }
    ],
    "source": [
-    "import pickle\n",
     "import pandas as pd\n",
     "from sklearn.metrics import confusion_matrix\n",
     "\n",
     "experiment = project.experiments(tags=[\"parameter search\"])[-1]\n",
     "\n",
     "trained_model = pipeline._final_estimator\n",
-    "experiment.log_artifact(data_bytes=pickle.dumps(trained_model), name=\"trained model\")\n",
+    "experiment.log_artifact(data_object=trained_model, name=\"trained model\")\n",
     "\n",
     "y_pred = pipeline.predict(X_test)\n",
     "confusion_matrix_df = pd.DataFrame(\n",
@@ -678,7 +677,7 @@
     ")\n",
     "experiment.log_dataframe(confusion_matrix_df, name=\"confusion matrix\")\n",
     "\n",
-    "print(pickle.loads(experiment.artifact(name=\"trained model\").data))\n",
+    "print(experiment.artifact(name=\"trained model\").get_data(unpickle=True))\n",
     "experiment.dataframe(name=\"confusion matrix\").get_data()"
    ]
   }


### PR DESCRIPTION
## What
  * Adds changes to `notebooks/quick-look/logging_experiments.ipynb` that reflect the artifact logging enhancement which allows users to log python objects as artifacts

## How to Test
  * run last cell of notebook
