### PR TITLE
update `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,9 +39,9 @@ install_requires =
 	scikit-learn<=1.1.3,>=0.22.0
 
 [options.extras_require]
-prefect_requires = 
+prefect = 
 	prefect<=1.2.4,>=0.12.0
-ui_requires = 
+ui = 
 	dash<=2.7.0,>=2.0.0
 	dash-bootstrap-components<=1.2.1,>=1.0.0
 all = 


### PR DESCRIPTION
## What
  * just realized that `pip install rubicon-ml[ui]` doesnt work - `pip install rubicon-ml[ui-requires]` does
  * changes the keys in the section for optional requirements

