### PR TITLE
tag bug fix in experiment table

### DIFF
--- a/rubicon_ml/viz/experiments_table.py
+++ b/rubicon_ml/viz/experiments_table.py
@@ -238,7 +238,7 @@ class ExperimentsTable(VizBase):
                 "created_at": experiment.created_at,
                 "model_name": experiment.model_name,
                 "commit_hash": None,
-                "tags": experiment.tags,
+                "tags": ", ".join(str(tag) for tag in experiment.tags),
             }
 
             if experiment.commit_hash is not None:


### PR DESCRIPTION
closes: #317 

---

## What
  * Bug fix for the way tags were being displayed in the experiment table
  * Tags are now comma separated with a space character in the table

## How to Test
  * "run the code in this example, but change experiment = project.log_experiment() to experiment = 
     project.log_experiment(tags=["tag_a", "tag_b"]), then take a look at the tags column in the experiments table"
     https://capitalone.github.io/rubicon-ml/visualizations/experiments-table.html



