### PR TITLE
encode/decode `numpy` objects

### DIFF
--- a/rubicon_ml/repository/utils/json.py
+++ b/rubicon_ml/repository/utils/json.py
@@ -1,6 +1,9 @@
 import dataclasses
 import json
+from base64 import b64decode, b64encode
 from datetime import date, datetime
+
+import numpy as np
 
 from rubicon_ml.domain.utils import TrainingMetadata
 
@@ -13,13 +16,20 @@ class DomainJSONEncoder(json.JSONEncoder):
         """
         if isinstance(obj, datetime):
             return {"_type": "datetime", "value": obj.strftime("%Y-%m-%d %H:%M:%S.%f")}
-        if isinstance(obj, date):
+        elif isinstance(obj, date):
             return {"_type": "date", "value": obj.isoformat()}
-        if isinstance(obj, set):
+        elif isinstance(obj, set):
             return {"_type": "set", "value": list(obj)}
-        if isinstance(obj, TrainingMetadata):
+        elif isinstance(obj, TrainingMetadata):
             return {"_type": "training_metadata", "value": obj.training_metadata}
-        if dataclasses.is_dataclass(obj):
+        elif isinstance(obj, (np.generic, np.ndarray)):
+            return {
+                "_type": "numpy",
+                "_dtype": np.lib.format.dtype_to_descr(obj.dtype),
+                "_shape": obj.shape,
+                "value": b64encode(obj.tobytes()).decode(),
+            }
+        elif dataclasses.is_dataclass(obj):
             return obj.__dict__
         else:
             return super().default(obj)  # pragma: no cover
@@ -32,14 +42,24 @@ class DomainJSONDecoder(json.JSONDecoder):
     def object_hook(self, obj):
         if obj.get("_type") == "datetime":
             return datetime.strptime(obj.get("value"), "%Y-%m-%d %H:%M:%S.%f")
-        if obj.get("_type") == "date":
+        elif obj.get("_type") == "date":
             return date.fromisoformat(obj.get("value"))
-        if obj.get("_type") == "set":
+        elif obj.get("_type") == "set":
             return set(obj.get("value"))
-        if obj.get("_type") == "training_metadata":
+        elif obj.get("_type") == "training_metadata":
             return TrainingMetadata([(*o,) for o in obj.get("value")])
+        elif obj.get("_type") == "numpy":
+            dtype = np.lib.format.descr_to_dtype(obj.get("_dtype"))
+            shape = obj.get("_shape")
+            value = np.frombuffer(b64decode(obj.get("value")), dtype)
+
+            return value.reshape(shape) if shape else value[0]
         else:
             return obj
+
+
+def dump(data):
+    return json.dump(data, cls=DomainJSONEncoder)
 
 
 def dumps(data):

--- a/rubicon_ml/repository/utils/json.py
+++ b/rubicon_ml/repository/utils/json.py
@@ -58,17 +58,17 @@ class DomainJSONDecoder(json.JSONDecoder):
             return obj
 
 
-def dump(data):
-    return json.dump(data, cls=DomainJSONEncoder)
+def dump(data, open_file, **kwargs):
+    return json.dump(data, open_file, cls=DomainJSONEncoder, **kwargs)
 
 
-def dumps(data):
-    return json.dumps(data, cls=DomainJSONEncoder)
+def dumps(data, **kwargs):
+    return json.dumps(data, cls=DomainJSONEncoder, **kwargs)
 
 
-def load(open_file):
-    return json.load(open_file, cls=DomainJSONDecoder)
+def load(open_file, **kwargs):
+    return json.load(open_file, cls=DomainJSONDecoder, **kwargs)
 
 
-def loads(data):
-    return json.loads(data, cls=DomainJSONDecoder)
+def loads(data, **kwargs):
+    return json.loads(data, cls=DomainJSONDecoder, **kwargs)


### PR DESCRIPTION
## What
  * adds support for `numpy` generics and arrays to the JSON serializer

## How to Test
  * run the new tests: `python -m pytest tests/unit/repository/utils/test_json.py`
  * try logging some parameters or metrics with `numpy` types:

```python
experiment.log_metric(name="int32", value=np.int32(5))
experiment.log_metric(name="ndarray", value=np.array([np.float32(0.5)]*4).reshape((2, 2)))
```
