### PR TITLE
deploy pages action version

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -36,7 +36,7 @@ jobs:
         cd docs
         make html
     - name: Publish
-      uses: JamesIves/github-pages-deploy-action@4.0.0
+      uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: gh-pages
         folder: docs/build/html


### PR DESCRIPTION
## What
  * loosens the strict 4.0.0 versioning on the publish pages action to use the latest (4.4.1)

## How to test
  * https://github.com/capitalone/rubicon-ml/actions/runs/3678876935