### PR TITLE
Rubicon json cli integration

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - PyYAML<=6.0,>=5.4.0
   - s3fs<=2022.11.0,>=0.4
   - scikit-learn<=1.1.3,>=0.22.0
-
+  - jsonpath_ng<=2.7.0,>=2.6.0
   # for prefect workflows
   - prefect<=1.2.4,>=0.12.0
 

--- a/rubicon_ml/cli.py
+++ b/rubicon_ml/cli.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import warnings
 
 import click
@@ -117,31 +118,16 @@ def search(root_dir, project_name, color, query):
     directly and output the JSON in the command line.
     """
 
-    proj_name_env = "RUBICON_PROJECT_NAME"
-    root_dir_env = "RUBICON_ROOT_DIR"
-    fg_color = "bright_yellow"
-
-    if (proj_name_env not in os.environ and project_name is None) or (
-        root_dir_env not in os.environ and root_dir is None
-    ):
-        warnings.warn(
-            "No --root-dir or --project-name provided. Exiting..."
-        )
-        return
-
-    if not project_name:
-        project_name = os.environ["RUBICON_PROJECT_NAME"]
-    if not root_dir:
-        root_dir = os.environ["RUBICON_ROOT_DIR"]
+    if project_name is None or root_dir is None:
+        click.secho("No --root-dir or --project-name provided. Exiting...", fg="red")
+        sys.exit()
 
     rubicon = Rubicon(persistence="filesystem", root_dir=root_dir)
     try:
         project = rubicon.get_project(name=project_name)
-    except Exception:
-        warnings.warn(
-            "Rubicon project not found with given name, try again with a different project name"
-        )
-        return
+    except Exception as e:
+        click.secho(e, fg="red")
+        sys.exit()
 
     rb_json = RubiconJSON(projects=project)
     res = rb_json.search(query)

--- a/rubicon_ml/cli.py
+++ b/rubicon_ml/cli.py
@@ -125,7 +125,7 @@ def search(root_dir, project_name, color, query):
         root_dir_env not in os.environ and root_dir is None
     ):
         warnings.warn(
-            "No previous project name and/or Rubicon root directory saved, enter a new one"
+            "No --root-dir or --project-name provided. Exiting..."
         )
         return
 

--- a/rubicon_ml/cli.py
+++ b/rubicon_ml/cli.py
@@ -1,4 +1,5 @@
 import os
+import pprint
 import sys
 import warnings
 
@@ -107,12 +108,20 @@ def ui(root_dir, page_size, project_name, host, port, debug, storage_options):
     help="Color of query output",
     required=False,
 )
+@click.option(
+    "--bf",
+    is_flag=True,
+    show_default=True,
+    default=True,
+    required=False,
+    help="Flag that switches pretty print output format to basic format",
+)
 @click.argument(
     "query",
     nargs=1,
     required=True,
 )
-def search(root_dir, project_name, color, query):
+def search(root_dir, project_name, color, bf, query):
     """
     This function provides capability to query  rubicon experiments from the command line without using python
     directly and output the JSON in the command line.
@@ -131,11 +140,15 @@ def search(root_dir, project_name, color, query):
 
     rb_json = RubiconJSON(projects=project)
     res = rb_json.search(query)
-
+    if not isinstance(res, list):
+        res = [res]
+    matches = [r.value for r in res]
     if "color" in click.get_current_context().params:
         fg_color = color
 
-    click.secho(res, fg=fg_color)
+    result = matches if bf else pprint.pformat(matches, indent=1)
+
+    click.secho(result, fg=fg_color)
 
 
 # CLI groups

--- a/rubicon_ml/cli.py
+++ b/rubicon_ml/cli.py
@@ -3,6 +3,7 @@ import warnings
 import click
 
 from rubicon_ml import Rubicon
+from rubicon_ml.client.rubicon_json import RubiconJSON
 from rubicon_ml.viz import Dashboard
 
 
@@ -76,6 +77,34 @@ def ui(root_dir, page_size, project_name, host, port, debug, storage_options):
     run_server_kwargs = dict(debug=debug, port=port, host=host)
     run_server_kwargs = {k: v for k, v in run_server_kwargs.items() if v is not None}
     dashboard.serve(run_server_kwargs=run_server_kwargs)
+
+
+@cli.command(
+    context_settings=dict(
+        ignore_unknown_options=True,
+    )
+)
+@click.option(
+    "--root-dir",
+    type=click.STRING,
+    help="The absolute path to the top level folder holding the rubicon-ml project.",
+    required=True,
+)
+@click.option(
+    "--project_name",
+    type=click.STRING,
+    help="Name of rubicon project to retrieve experiments from",
+    required=True,
+)
+@click.argument(
+    "query",
+    nargs=1,
+    required=True,
+)
+def json(project_name, query):
+    rb_json = RubiconJSON(projects=project_name)
+    experiments = rb_json.search(query)
+    return experiments
 
 
 # CLI groups

--- a/rubicon_ml/cli.py
+++ b/rubicon_ml/cli.py
@@ -129,14 +129,14 @@ def search(root_dir, project_name, color, bf, query):
 
     if project_name is None or root_dir is None:
         click.secho("No --root-dir or --project-name provided. Exiting...", fg="red")
-        sys.exit()
+        sys.exit(1)
 
     rubicon = Rubicon(persistence="filesystem", root_dir=root_dir)
     try:
         project = rubicon.get_project(name=project_name)
     except Exception as e:
         click.secho(e, fg="red")
-        sys.exit()
+        sys.exit(1)
 
     rb_json = RubiconJSON(projects=project)
     res = rb_json.search(query)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -210,25 +210,3 @@ def viz_experiments(rubicon_and_project_client):
         experiment.log_dataframe(data_df, name="test dataframe")
 
     return project.experiments()
-
-
-@pytest.fixture
-def control_env_vars():
-    print("--deleting and restoring env variables--")
-    # Store existing environment variables
-    env_proj_name = (
-        os.environ["RUBICON_PROJECT_NAME"] if "RUBICON_PROJECT_NAME" in os.environ else "n/a"
-    )
-    env_root_dir = os.environ["RUBICON_ROOT_DIR"] if "RUBICON_ROOT_DIR" in os.environ else "n/a"
-
-    # Delete environemnt variables for testing
-    os.environ.pop("RUBICON_PROJECT_NAME", None)
-    os.environ.pop("RUBICON_ROOT_DIR", None)
-
-    yield
-
-    # Restore environment variables after testing
-    if env_proj_name != "n/a":
-        os.environ["RUBICON_PROJECT_NAME"] = env_proj_name
-    if env_root_dir != "n/a":
-        os.environ["RUBICON_ROOT_DIR"] = env_root_dir

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -210,3 +210,25 @@ def viz_experiments(rubicon_and_project_client):
         experiment.log_dataframe(data_df, name="test dataframe")
 
     return project.experiments()
+
+
+@pytest.fixture
+def control_env_vars():
+    print("--deleting and restoring env variables--")
+    # Store existing environment variables
+    env_proj_name = (
+        os.environ["RUBICON_PROJECT_NAME"] if "RUBICON_PROJECT_NAME" in os.environ else "n/a"
+    )
+    env_root_dir = os.environ["RUBICON_ROOT_DIR"] if "RUBICON_ROOT_DIR" in os.environ else "n/a"
+
+    # Delete environemnt variables for testing
+    os.environ.pop("RUBICON_PROJECT_NAME", None)
+    os.environ.pop("RUBICON_ROOT_DIR", None)
+
+    yield
+
+    # Restore environment variables after testing
+    if env_proj_name != "n/a":
+        os.environ["RUBICON_PROJECT_NAME"] = env_proj_name
+    if env_root_dir != "n/a":
+        os.environ["RUBICON_ROOT_DIR"] = env_root_dir

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,3 +1,4 @@
+import os
 import warnings
 from unittest.mock import patch
 
@@ -60,45 +61,43 @@ def test_search_cli(project_client):
 
     project.log_artifact(name="p", data_bytes=b"p")
 
-    with warnings.catch_warnings(record=True) as caught_warnings_a:
-        runner = CliRunner()
-        result_a = runner.invoke(
-            cli,
-            [
-                "search",
-                "--root-dir",
-                project.repository.root_dir,
-                "--project-name",
-                project.name,
-                QUERY,
-            ],
-        )
+    runner = CliRunner()
+    result_a = runner.invoke(
+        cli,
+        [
+            "search",
+            "--root-dir",
+            project.repository.root_dir,
+            "--project-name",
+            project.name,
+            QUERY,
+        ],
+    )
 
-    with warnings.catch_warnings(record=True) as caught_warnings_b:
-        runner = CliRunner()
-        result_b = runner.invoke(cli, ["search", QUERY])
+    runner = CliRunner()
 
-    with warnings.catch_warnings(record=True) as caught_warnings_c:
-        runner = CliRunner()
-        result_c = runner.invoke(
-            cli,
-            [
-                "search",
-                "--root-dir",
-                project.repository.root_dir,
-                "--project-name",
-                project.name,
-                "--color",
-                TEST_COLOR,
-                QUERY,
-            ],
-        )
+    # Delte existing environment variables for testing purposes
+    os.environ.pop("RUBICON_PROJECT_NAME", None)
+    os.environ.pop("RUBICON_ROOT_DIR", None)
+
+    result_b = runner.invoke(cli, ["search", QUERY])
+
+    runner = CliRunner()
+    result_c = runner.invoke(
+        cli,
+        [
+            "search",
+            "--root-dir",
+            project.repository.root_dir,
+            "--project-name",
+            project.name,
+            "--color",
+            TEST_COLOR,
+            QUERY,
+        ],
+    )
 
     assert result_a.exit_code == 0
-    assert len(caught_warnings_a) == 0
-    assert "No --root-dir or --project-name provided. Exiting..." in str(
-        caught_warnings_b[0]
-    )
+    assert "No --root-dir or --project-name provided. Exiting..." in result_b.output
     assert result_b.exit_code == 0
     assert result_c.exit_code == 0
-    assert len(caught_warnings_c) == 0

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,4 +1,3 @@
-import os
 import warnings
 from unittest.mock import patch
 
@@ -35,7 +34,7 @@ def test_cli(mock_get_project, mock_projects, mock_run_server, project_client):
         assert "`--project-name` will be a required option" in str(caught_warnings[1])
 
 
-def test_search_cli(project_client):
+def test_search_cli(project_client, control_env_vars):
 
     project = project_client
     NUM_EXPERIMENTS = 4
@@ -75,12 +74,9 @@ def test_search_cli(project_client):
     )
 
     runner = CliRunner()
-
-    # Delte existing environment variables for testing purposes
-    os.environ.pop("RUBICON_PROJECT_NAME", None)
-    os.environ.pop("RUBICON_ROOT_DIR", None)
-
-    result_b = runner.invoke(cli, ["search", QUERY])
+    result_b = runner.invoke(
+        cli, ["search", QUERY], env={"RUBICON_PROJECT_NAME": None, "RUBICON_ROOT_DIR": None}
+    )
 
     runner = CliRunner()
     result_c = runner.invoke(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -34,12 +34,8 @@ def test_cli(mock_get_project, mock_projects, mock_run_server, project_client):
         assert "`--project-name` will be a required option" in str(caught_warnings[1])
 
 
-def test_search_cli(project_client, control_env_vars):
-
-    project = project_client
+def _set_up_rubicon_project(project):
     NUM_EXPERIMENTS = 4
-    QUERY = "$..experiment[*].metric"
-    TEST_COLOR = "yellow"
     for _ in range(NUM_EXPERIMENTS):
         tags = ["a", "b", "c"]
         ex = project.log_experiment(tags=tags)
@@ -60,6 +56,14 @@ def test_search_cli(project_client, control_env_vars):
 
     project.log_artifact(name="p", data_bytes=b"p")
 
+    return project
+
+
+def test_search_cli_base(rubicon_local_filesystem_client_with_project):
+    _, project = rubicon_local_filesystem_client_with_project
+    QUERY = "$..experiment[*].metric"
+    project = _set_up_rubicon_project(project=project)
+
     runner = CliRunner()
     result_a = runner.invoke(
         cli,
@@ -71,15 +75,51 @@ def test_search_cli(project_client, control_env_vars):
             project.name,
             QUERY,
         ],
+        env={"RUBICON_PROJECT_NAME": None, "RUBICON_ROOT_DIR": None},
     )
 
+    assert result_a.exit_code == 0
+
+
+def test_search_cli_exp_fail(rubicon_local_filesystem_client_with_project):
+
+    _, project = rubicon_local_filesystem_client_with_project
+    QUERY = "$..experiment[*].metric"
+    project = _set_up_rubicon_project(project=project)
+
     runner = CliRunner()
-    result_b = runner.invoke(
+    result_a = runner.invoke(
         cli, ["search", QUERY], env={"RUBICON_PROJECT_NAME": None, "RUBICON_ROOT_DIR": None}
     )
 
+    result_b = runner.invoke(
+        cli,
+        [
+            "search",
+            "--root-dir",
+            project.repository.root_dir,
+            "--project-name",
+            "NON-EXISTENT-PROJECT",
+            QUERY,
+        ],
+        env={"RUBICON_PROJECT_NAME": None, "RUBICON_ROOT_DIR": None},
+    )
+
+    assert "No --root-dir or --project-name provided. Exiting..." in result_a.output
+    assert "No project with name 'NON-EXISTENT-PROJECT' found." in result_b.output
+    assert result_a.exit_code == 1
+    assert result_b.exit_code == 1
+
+
+def test_search_cli_color(rubicon_local_filesystem_client_with_project):
+    _, project = rubicon_local_filesystem_client_with_project
+
+    QUERY = "$..experiment[*].metric"
+    TEST_COLOR = "yellow"
+    project = _set_up_rubicon_project(project=project)
+
     runner = CliRunner()
-    result_c = runner.invoke(
+    result = runner.invoke(
         cli,
         [
             "search",
@@ -91,9 +131,7 @@ def test_search_cli(project_client, control_env_vars):
             TEST_COLOR,
             QUERY,
         ],
+        env={"RUBICON_PROJECT_NAME": None, "RUBICON_ROOT_DIR": None},
     )
 
-    assert result_a.exit_code == 0
-    assert "No --root-dir or --project-name provided. Exiting..." in result_b.output
-    assert result_b.exit_code == 0
-    assert result_c.exit_code == 0
+    assert result.exit_code == 0

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -96,7 +96,7 @@ def test_search_cli(project_client):
 
     assert result_a.exit_code == 0
     assert len(caught_warnings_a) == 0
-    assert "No previous project name and/or Rubicon root directory saved, enter a new one" in str(
+    assert "No --root-dir or --project-name provided. Exiting..." in str(
         caught_warnings_b[0]
     )
     assert result_b.exit_code == 0


### PR DESCRIPTION
closes: #313  

---

## What
  *  Adds functionality to retrieve rubicon experiments via the CLI
  * CLI takes in `project-name` `root-dir` and `color` as optional inputs
  * Gives users the ability to set `root-dir` and `project-name` as environment variables for future reference
  * Testing
  

## How to Test
  * run pytest 
  * run  snippet on CLI as sample `rubicon_ml search --root-dir ./rubicon-root --project-name "my project" "$..experiment[*].metric"`
