### PR TITLE
added search return_type functionality and unit testing

### DIFF
--- a/rubicon_ml/client/rubicon_json.py
+++ b/rubicon_ml/client/rubicon_json.py
@@ -35,7 +35,8 @@ class RubiconJSON:
 
     def search(self, query, return_type=None):
         if return_type is not None:
-            if return_type.lower() not in [
+            return_type = return_type.lower()
+            if return_type not in [
                 "artifact",
                 "dataframe",
                 "experiment",
@@ -45,7 +46,7 @@ class RubiconJSON:
                 "project",
             ]:
                 raise ValueError(
-                    "`return_type` must be artifact, dataframe, experiment, featrure, metric, parameter, or project."
+                    "`return_type` must be artifact, dataframe, experiment, feature, metric, parameter, or project."
                 )
 
         res = parse(query).find(self._json)
@@ -65,16 +66,9 @@ class RubiconJSON:
                     )
         elif return_type == "experiment":
             for match in res:
-                if match.value.get("feature") is not None:
-                    del match.value["feature"]
-                if match.value.get("parameter") is not None:
-                    del match.value["parameter"]
-                if match.value.get("metric") is not None:
-                    del match.value["metric"]
-                if match.value.get("artifact") is not None:
-                    del match.value["artifact"]
-                if match.value.get("dataframe") is not None:
-                    del match.value["dataframe"]
+                for key in ["feature", "parameter", "metric", "artifact", "dataframe"]:
+                    if key in match.value:
+                        del match.value[key]
                 return_objects.append(Experiment(DomainExperiment(**match.value), NoOpParent()))
         elif return_type == "feature":
             for match in res:
@@ -92,13 +86,9 @@ class RubiconJSON:
                     )
         elif return_type == "project":
             for match in res:
-                print(match.value)
-                if match.value.get("artifact") is not None:
-                    del match.value["artifact"]
-                if match.value.get("dataframe") is not None:
-                    del match.value["dataframe"]
-                if match.value.get("experiment") is not None:
-                    del match.value["experiment"]
+                for key in ["artifact", "dataframe", "experiment"]:
+                    if key in match.value:
+                        del match.value[key]
                 return_objects.append(Project(DomainProject(**match.value), NoOpParent()))
 
         return return_objects

--- a/rubicon_ml/client/rubicon_json.py
+++ b/rubicon_ml/client/rubicon_json.py
@@ -1,14 +1,107 @@
 from jsonpath_ng.ext import parse
 
-from rubicon_ml.client import Experiment, Project, Rubicon
+from rubicon_ml.client import (
+    Artifact,
+    Dataframe,
+    Experiment,
+    Feature,
+    Metric,
+    Parameter,
+    Project,
+    Rubicon,
+)
+from rubicon_ml.domain import (
+    Artifact as DomainArtifact,
+    Dataframe as DomainDataframe,
+    Experiment as DomainExperiment,
+    Feature as DomainFeature,
+    Metric as DomainMetric,
+    Parameter as DomainParameter,
+    Project as DomainProject,
+)
+
+
+class NoOpParent:
+    """A read-only parent object"""
+
+    @property
+    def _config(self):
+        return None
 
 
 class RubiconJSON:
     def __init__(self, rubicon_objects=None, projects=None, experiments=None):
         self._json = self._convert_to_json(rubicon_objects, projects, experiments)
 
-    def search(self, query):
-        return parse(query).find(self._json)
+    def search(self, query, return_type=None):
+        if return_type is not None:
+            if return_type.lower() not in [
+                "artifact",
+                "dataframe",
+                "experiment",
+                "feature",
+                "metric",
+                "parameter",
+                "project",
+            ]:
+                raise ValueError(
+                    "`return_type` must be artifact, dataframe, experiment, featrure, metric, parameter, or project."
+                )
+
+        res = parse(query).find(self._json)
+        if not return_type:
+            return res
+
+        return_objects = []
+        if return_type == "artifact":
+            for match in res:
+                for i in range(len(match.value)):
+                    return_objects.append(Artifact(DomainArtifact(**match.value[i]), NoOpParent()))
+        elif return_type == "dataframe":
+            for match in res:
+                for i in range(len(match.value)):
+                    return_objects.append(
+                        Dataframe(DomainDataframe(**match.value[i]), NoOpParent())
+                    )
+        elif return_type == "experiment":
+            for match in res:
+                if match.value.get("feature") is not None:
+                    del match.value["feature"]
+                if match.value.get("parameter") is not None:
+                    del match.value["parameter"]
+                if match.value.get("metric") is not None:
+                    del match.value["metric"]
+                if match.value.get("artifact") is not None:
+                    del match.value["artifact"]
+                if match.value.get("dataframe") is not None:
+                    del match.value["dataframe"]
+                return_objects.append(Experiment(DomainExperiment(**match.value), NoOpParent()))
+        elif return_type == "feature":
+            for match in res:
+                for i in range(len(match.value)):
+                    return_objects.append(Feature(DomainFeature(**match.value[i]), NoOpParent()))
+        elif return_type == "metric":
+            for match in res:
+                for i in range(len(match.value)):
+                    return_objects.append(Metric(DomainMetric(**match.value[i]), NoOpParent()))
+        elif return_type == "parameter":
+            for match in res:
+                for i in range(len(match.value)):
+                    return_objects.append(
+                        Parameter(DomainParameter(**match.value[i]), NoOpParent())
+                    )
+        elif return_type == "project":
+            for match in res:
+                print(match.value)
+                if match.value.get("artifact") is not None:
+                    del match.value["artifact"]
+                if match.value.get("dataframe") is not None:
+                    del match.value["dataframe"]
+                if match.value.get("experiment") is not None:
+                    del match.value["experiment"]
+                return_objects.append(Project(DomainProject(**match.value), NoOpParent()))
+
+        return return_objects
 
     def _convert_to_json(self, rubicon_objects=None, projects=None, experiments=None):
 

--- a/tests/unit/client/test_rubicon_json_client.py
+++ b/tests/unit/client/test_rubicon_json_client.py
@@ -1,7 +1,17 @@
 import pandas as pd
 import pytest
 
-from rubicon_ml.client import Rubicon, RubiconJSON
+from rubicon_ml.client import (
+    Artifact,
+    Dataframe,
+    Experiment,
+    Feature,
+    Metric,
+    Parameter,
+    Project,
+    Rubicon,
+    RubiconJSON,
+)
 
 
 def test_experiment_to_json_single_experiment(rubicon_and_project_client):
@@ -160,7 +170,7 @@ def test_convert_to_json_projects_and_experiments_input(
     assert len(json["experiment"]) == 2
 
 
-def test_search(rubicon_and_project_client_with_experiments):
+def test_search_return_type_none(rubicon_and_project_client_with_experiments):
     rubicon, _ = rubicon_and_project_client_with_experiments
     rubicon_json = RubiconJSON(rubicon_objects=rubicon)
 
@@ -168,3 +178,80 @@ def test_search(rubicon_and_project_client_with_experiments):
 
     assert len(res) == 10
     assert [len(metric.value) == 1 for metric in res]
+
+
+def test_search_return_type_incorrect(rubicon_and_project_client_with_experiments):
+    rubicon, _ = rubicon_and_project_client_with_experiments
+    rubicon_json = RubiconJSON(rubicon_objects=rubicon)
+
+    with pytest.raises(ValueError) as e:
+        rubicon_json.search("$..experiment[*].metric", return_type="rubicon")
+
+    assert (
+        "`return_type` must be artifact, dataframe, experiment, featrure, metric, parameter, or project."
+        in str(e)
+    )
+
+
+def test_search_return_type_artifact(rubicon_and_project_client):
+    _, project = rubicon_and_project_client
+    ex = project.log_experiment(name="test")
+    ex.log_artifact(name="artifact1", data_bytes=b"a1")
+    ex.log_artifact(name="artifact2", data_bytes=b"a2")
+
+    rubicon_json = RubiconJSON(projects=project)
+    res = rubicon_json.search("$..experiment[*].artifact", return_type="artifact")
+
+    assert [isinstance(item, Artifact) for item in res]
+
+
+def test_search_return_type_dataframe(rubicon_and_project_client):
+    _, project = rubicon_and_project_client
+    ex = project.log_experiment(name="test")
+    ex.log_dataframe(pd.DataFrame([[0, 1], [1, 0]]))
+    ex.log_dataframe(pd.DataFrame([[0, 2], [2, 0]]))
+
+    rubicon_json = RubiconJSON(projects=project)
+    res = rubicon_json.search("$..experiment[*].dataframe", return_type="dataframe")
+
+    assert [isinstance(item, Dataframe) for item in res]
+
+
+def test_search_return_type_experiment(rubicon_and_project_client_with_experiments):
+    _, project = rubicon_and_project_client_with_experiments
+    rubicon_json = RubiconJSON(projects=project)
+    res = rubicon_json.search("$..experiment[*]", return_type="experiment")
+
+    assert [isinstance(item, Experiment) for item in res]
+
+
+def test_search_return_type_feature(rubicon_and_project_client_with_experiments):
+    _, project = rubicon_and_project_client_with_experiments
+    rubicon_json = RubiconJSON(projects=project)
+    res = rubicon_json.search("$..experiment[*].feature", return_type="feature")
+
+    assert [isinstance(item, Feature) for item in res]
+
+
+def test_search_return_type_metric(rubicon_and_project_client_with_experiments):
+    _, project = rubicon_and_project_client_with_experiments
+    rubicon_json = RubiconJSON(projects=project)
+    res = rubicon_json.search("$..experiment[*].metric", return_type="metric")
+
+    assert [isinstance(item, Metric) for item in res]
+
+
+def test_search_return_type_parameter(rubicon_and_project_client_with_experiments):
+    _, project = rubicon_and_project_client_with_experiments
+    rubicon_json = RubiconJSON(projects=project)
+    res = rubicon_json.search("$..experiment[*].parameter", return_type="parameter")
+
+    assert [isinstance(item, Parameter) for item in res]
+
+
+def test_search_return_type_project(rubicon_and_project_client_with_experiments):
+    rubicon, _ = rubicon_and_project_client_with_experiments
+    rubicon_json = RubiconJSON(rubicon_objects=rubicon)
+    res = rubicon_json.search("$..project[*]", return_type="project")
+
+    assert [isinstance(item, Project) for item in res]

--- a/tests/unit/client/test_rubicon_json_client.py
+++ b/tests/unit/client/test_rubicon_json_client.py
@@ -188,7 +188,7 @@ def test_search_return_type_incorrect(rubicon_and_project_client_with_experiment
         rubicon_json.search("$..experiment[*].metric", return_type="rubicon")
 
     assert (
-        "`return_type` must be artifact, dataframe, experiment, featrure, metric, parameter, or project."
+        "`return_type` must be artifact, dataframe, experiment, feature, metric, parameter, or project."
         in str(e)
     )
 


### PR DESCRIPTION
closes: #314

---

## What
  * Adds functionality to `RubiconJSON.search` that now allows users to retrieve rubicon objects as well (previously json strings only)
  * Adds unit testing for 100% file coverage

## How to Test
  * run `python -m pytest tests/unit/client/test_rubicon_json_client.py`
