### PR TITLE
Adding RubiconJSON docs notebook + API Reference

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -78,6 +78,13 @@ publish
 
 .. autofunction:: rubicon_ml.publish
 
+.. _library-reference-rubiconJSON:
+
+RubiconJSON
+===========
+.. autoclass:: rubicon_ml.RubiconJSON
+   :members: search
+
 .. _library-reference-sklearn:
 
 sklearn

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -116,6 +116,7 @@ To install all extra modules, use the ``all`` extra.
    logging-examples/logging-plots
    logging-examples/logging-concurrently
    logging-examples/tagging
+   logging-examples/rubiconJSON-querying
    visualizations.rst
 
 .. toctree::

--- a/notebooks/logging-examples/rubiconJSON-querying.ipynb
+++ b/notebooks/logging-examples/rubiconJSON-querying.ipynb
@@ -1,11 +1,12 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f02a8c8d",
    "metadata": {},
    "source": [
-    "# Query Rubcion Logs with RubiconJSON\n",
+    "# Querying Rubcion Logs with RubiconJSON\n",
     "\n",
     "If we want to query our Rubicon logs in an easy way, we can utilize the `RubiconJSON` class to query Rubicon logs in a JSONPath-like manner. `RubiconJSON` can take in top-level `rubicon_ml` objects, `projects`, and/or `experiments` and will return a json `dict`. We can call `search` on a `RubiconJSON` returned json for JSONPath-like querying by relying on the `jsonpath_ng` python implementation (https://github.com/h2non/jsonpath-ng) under the hood. \n"
    ]

--- a/notebooks/logging-examples/rubiconJSON-querying.ipynb
+++ b/notebooks/logging-examples/rubiconJSON-querying.ipynb
@@ -1,0 +1,658 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f02a8c8d",
+   "metadata": {},
+   "source": [
+    "# Query Rubcion Logs with RubiconJSON\n",
+    "\n",
+    "If we want to query our Rubicon logs in an easy way, we can utilize the `RubiconJSON` class to query Rubicon logs in a JSONPath-like manner. `RubiconJSON` can take in top-level `rubicon_ml` objects, `projects`, and/or `experiments` and will return a json `dict`. We can call `search` on a `RubiconJSON` returned json for JSONPath-like querying by relying on the `jsonpath_ng` python implementation (https://github.com/h2non/jsonpath-ng) under the hood. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "346b64f7",
+   "metadata": {},
+   "source": [
+    "### Let's create some example `rubicon_ml` objects for demonstration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "8867f7a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "\n",
+    "random.seed(24)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a811cb89",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<rubicon_ml.client.project.Project at 0x1374d95d0>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "from rubicon_ml import Rubicon\n",
+    "\n",
+    "NUM_EXPERIMENTS = 4\n",
+    "\n",
+    "rb = Rubicon(persistence=\"memory\")\n",
+    "pr = rb.get_or_create_project(name=\"jsonpath\")\n",
+    "\n",
+    "for _ in range(NUM_EXPERIMENTS):\n",
+    "    tags = [random.choice([\"a\", \"b\", \"c\"])]\n",
+    "    ex = pr.log_experiment(tags=tags)\n",
+    "        \n",
+    "    for feature in [\"f\", \"g\", \"h\", \"i\"]:\n",
+    "        ex.log_feature(name=feature)\n",
+    "            \n",
+    "    for parameter in [(\"d\", 100), (\"e\", 1000), (\"f\", 1000)]:\n",
+    "        name, value = parameter\n",
+    "        ex.log_parameter(name=name, value=value)\n",
+    "        \n",
+    "    for metric in [\"j\", \"k\"]:\n",
+    "        value = random.choice([0.0, 1.0])\n",
+    "        tags = [random.choice([\"l\", \"m\", \"n\"])]\n",
+    "        ex.log_metric(name=metric, value=value, tags=tags)\n",
+    "        \n",
+    "    ex.log_artifact(name=\"o\", data_bytes=b\"o\")\n",
+    "    ex.log_dataframe(pd.DataFrame([[0, 1], [1, 0]]))\n",
+    "    \n",
+    "pr.log_artifact(name=\"p\", data_bytes=b\"p\")\n",
+    "pr.log_dataframe(pd.DataFrame([[0, 1], [1, 0]]))\n",
+    "\n",
+    "pr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e252fe50",
+   "metadata": {},
+   "source": [
+    "### Demonstrating RubiconJSON class\n",
+    "\n",
+    "`RubiconJSON` can take in any combination of top-level \"rubicon_objects\" (single or `list`), \"projects\" (single or `list`), and \"experiments\" (single or `list`) as keyword arguments. It returns a `RubiconJSON` object that has a json property with the file structure shown above. Here we'll simply demonstrate with the example project we just created. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ec13d530",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'project': [{'name': 'jsonpath',\n",
+       "   'id': '14dc8759-8403-459b-876d-4bad6374a0a6',\n",
+       "   'description': None,\n",
+       "   'github_url': None,\n",
+       "   'training_metadata': None,\n",
+       "   'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 295975),\n",
+       "   'artifact': [{'name': 'p',\n",
+       "     'id': 'a62d1af0-27da-4a90-8277-b38761d475d7',\n",
+       "     'description': None,\n",
+       "     'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299675),\n",
+       "     'tags': [],\n",
+       "     'parent_id': '14dc8759-8403-459b-876d-4bad6374a0a6'}],\n",
+       "   'dataframe': [{'id': 'ec45458e-3258-432a-be53-91b380abdbd3',\n",
+       "     'name': None,\n",
+       "     'description': None,\n",
+       "     'tags': [],\n",
+       "     'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299832),\n",
+       "     'parent_id': '14dc8759-8403-459b-876d-4bad6374a0a6'}],\n",
+       "   'experiment': [{'project_name': 'jsonpath',\n",
+       "     'id': '6e97f0fb-505c-4460-9e5d-2741111f443f',\n",
+       "     'name': None,\n",
+       "     'description': None,\n",
+       "     'model_name': None,\n",
+       "     'branch_name': None,\n",
+       "     'commit_hash': None,\n",
+       "     'training_metadata': None,\n",
+       "     'tags': ['c'],\n",
+       "     'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 296237),\n",
+       "     'feature': [{'name': 'f',\n",
+       "       'id': '65679b29-7c55-418a-82dd-a6ddbdfd30d3',\n",
+       "       'description': None,\n",
+       "       'importance': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 296313)},\n",
+       "      {'name': 'g',\n",
+       "       'id': '0a24caed-b0ae-4641-8300-1accd8d76b0d',\n",
+       "       'description': None,\n",
+       "       'importance': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 296384)},\n",
+       "      {'name': 'h',\n",
+       "       'id': '5e0d9aaa-9aef-4bd2-8a80-aae57ae3038d',\n",
+       "       'description': None,\n",
+       "       'importance': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 296437)},\n",
+       "      {'name': 'i',\n",
+       "       'id': '3c673e04-ab67-4ca5-8684-b61cc6d661c5',\n",
+       "       'description': None,\n",
+       "       'importance': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 296484)}],\n",
+       "     'parameter': [{'name': 'd',\n",
+       "       'id': '79052e5a-5132-4ef8-9a41-2ccf2231fba6',\n",
+       "       'value': 100,\n",
+       "       'description': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 296531)},\n",
+       "      {'name': 'e',\n",
+       "       'id': '49f3ea0d-7800-45e2-a6e6-a5b79c9ff594',\n",
+       "       'value': 1000,\n",
+       "       'description': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 296588)},\n",
+       "      {'name': 'f',\n",
+       "       'id': 'e6f203a1-02c3-4488-98c5-71b74b64db5d',\n",
+       "       'value': 1000,\n",
+       "       'description': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 296633)}],\n",
+       "     'metric': [{'name': 'j',\n",
+       "       'value': 1.0,\n",
+       "       'id': '89b243a6-6687-44ad-84d2-5e2fd920f99c',\n",
+       "       'description': None,\n",
+       "       'directionality': 'score',\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 296681),\n",
+       "       'tags': ['n']},\n",
+       "      {'name': 'k',\n",
+       "       'value': 0.0,\n",
+       "       'id': '608deb15-bfde-4830-9aee-5324689f2d7c',\n",
+       "       'description': None,\n",
+       "       'directionality': 'score',\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 296744),\n",
+       "       'tags': ['l']}],\n",
+       "     'artifact': [{'name': 'o',\n",
+       "       'id': '1752be86-6423-444a-a636-87cf248aa690',\n",
+       "       'description': None,\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 296794),\n",
+       "       'tags': [],\n",
+       "       'parent_id': '6e97f0fb-505c-4460-9e5d-2741111f443f'}],\n",
+       "     'dataframe': [{'id': '2937778a-26ef-4b7a-8108-2bdf86bc6224',\n",
+       "       'name': None,\n",
+       "       'description': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297100),\n",
+       "       'parent_id': '6e97f0fb-505c-4460-9e5d-2741111f443f'}]},\n",
+       "    {'project_name': 'jsonpath',\n",
+       "     'id': 'cc1b8445-b67a-4007-a0bd-dbda2a56f8c5',\n",
+       "     'name': None,\n",
+       "     'description': None,\n",
+       "     'model_name': None,\n",
+       "     'branch_name': None,\n",
+       "     'commit_hash': None,\n",
+       "     'training_metadata': None,\n",
+       "     'tags': ['a'],\n",
+       "     'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297268),\n",
+       "     'feature': [{'name': 'f',\n",
+       "       'id': '8edfdcbe-29ff-4cad-afcf-25bb03e0eb3e',\n",
+       "       'description': None,\n",
+       "       'importance': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297317)},\n",
+       "      {'name': 'g',\n",
+       "       'id': '92890604-d1f2-4883-8957-14984417470b',\n",
+       "       'description': None,\n",
+       "       'importance': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297378)},\n",
+       "      {'name': 'h',\n",
+       "       'id': '7100bca1-2322-425f-a57e-65b12be7889d',\n",
+       "       'description': None,\n",
+       "       'importance': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297426)},\n",
+       "      {'name': 'i',\n",
+       "       'id': 'f7b7a878-10ca-4b2e-9ad2-1d19e7fdc12d',\n",
+       "       'description': None,\n",
+       "       'importance': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297472)}],\n",
+       "     'parameter': [{'name': 'd',\n",
+       "       'id': '26cfd40c-d215-4321-9339-890d943389b4',\n",
+       "       'value': 100,\n",
+       "       'description': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297517)},\n",
+       "      {'name': 'e',\n",
+       "       'id': 'a7e5526b-949b-464b-81ba-7b8f05465ae5',\n",
+       "       'value': 1000,\n",
+       "       'description': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297574)},\n",
+       "      {'name': 'f',\n",
+       "       'id': 'd1f24807-e8d5-4659-b604-666a877cdcc2',\n",
+       "       'value': 1000,\n",
+       "       'description': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297619)}],\n",
+       "     'metric': [{'name': 'j',\n",
+       "       'value': 0.0,\n",
+       "       'id': 'ad75fa80-864d-4f08-a144-0e7357464d4a',\n",
+       "       'description': None,\n",
+       "       'directionality': 'score',\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297664),\n",
+       "       'tags': ['l']},\n",
+       "      {'name': 'k',\n",
+       "       'value': 0.0,\n",
+       "       'id': '896626d1-f3cc-418d-b227-aabce774f83c',\n",
+       "       'description': None,\n",
+       "       'directionality': 'score',\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297724),\n",
+       "       'tags': ['n']}],\n",
+       "     'artifact': [{'name': 'o',\n",
+       "       'id': '93e1a1ab-cb74-4179-a9c8-2d0731c70fcb',\n",
+       "       'description': None,\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297772),\n",
+       "       'tags': [],\n",
+       "       'parent_id': 'cc1b8445-b67a-4007-a0bd-dbda2a56f8c5'}],\n",
+       "     'dataframe': [{'id': '576dda9a-0a4e-4b78-92a4-3e84a8ffc2dc',\n",
+       "       'name': None,\n",
+       "       'description': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297911),\n",
+       "       'parent_id': 'cc1b8445-b67a-4007-a0bd-dbda2a56f8c5'}]},\n",
+       "    {'project_name': 'jsonpath',\n",
+       "     'id': 'aea1e3ac-8d77-4537-80d3-a475e4cdab60',\n",
+       "     'name': None,\n",
+       "     'description': None,\n",
+       "     'model_name': None,\n",
+       "     'branch_name': None,\n",
+       "     'commit_hash': None,\n",
+       "     'training_metadata': None,\n",
+       "     'tags': ['a'],\n",
+       "     'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298047),\n",
+       "     'feature': [{'name': 'f',\n",
+       "       'id': '62d4bd53-51d4-41d2-a19e-5f378881e924',\n",
+       "       'description': None,\n",
+       "       'importance': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298093)},\n",
+       "      {'name': 'g',\n",
+       "       'id': '2c72ddea-4c01-4372-afaf-3f572afe2a77',\n",
+       "       'description': None,\n",
+       "       'importance': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298156)},\n",
+       "      {'name': 'h',\n",
+       "       'id': '6b164102-3162-4643-ada3-e013179a0e82',\n",
+       "       'description': None,\n",
+       "       'importance': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298202)},\n",
+       "      {'name': 'i',\n",
+       "       'id': '6dacad76-f666-4d1f-a1cd-22975eed4d96',\n",
+       "       'description': None,\n",
+       "       'importance': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298247)}],\n",
+       "     'parameter': [{'name': 'd',\n",
+       "       'id': 'acb0e36b-625c-4053-846d-ce1247898833',\n",
+       "       'value': 100,\n",
+       "       'description': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298292)},\n",
+       "      {'name': 'e',\n",
+       "       'id': '052fdb4c-4128-45fa-b13b-936924db65b4',\n",
+       "       'value': 1000,\n",
+       "       'description': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298353)},\n",
+       "      {'name': 'f',\n",
+       "       'id': 'cd67f4c1-2ed5-4887-af0f-023244929ef9',\n",
+       "       'value': 1000,\n",
+       "       'description': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298398)}],\n",
+       "     'metric': [{'name': 'j',\n",
+       "       'value': 1.0,\n",
+       "       'id': '3ee54ec9-64f0-47e1-8549-cb41e1049480',\n",
+       "       'description': None,\n",
+       "       'directionality': 'score',\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298445),\n",
+       "       'tags': ['n']},\n",
+       "      {'name': 'k',\n",
+       "       'value': 0.0,\n",
+       "       'id': 'b4a00c05-f4a7-4633-ab1f-8fa031a8b8d8',\n",
+       "       'description': None,\n",
+       "       'directionality': 'score',\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298508),\n",
+       "       'tags': ['m']}],\n",
+       "     'artifact': [{'name': 'o',\n",
+       "       'id': '77c75b3f-ce0c-422a-8cd0-ae81eefaa99f',\n",
+       "       'description': None,\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298555),\n",
+       "       'tags': [],\n",
+       "       'parent_id': 'aea1e3ac-8d77-4537-80d3-a475e4cdab60'}],\n",
+       "     'dataframe': [{'id': '00e190d9-1cf0-4bd3-bdc7-7cacbaec1cf7',\n",
+       "       'name': None,\n",
+       "       'description': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298698),\n",
+       "       'parent_id': 'aea1e3ac-8d77-4537-80d3-a475e4cdab60'}]},\n",
+       "    {'project_name': 'jsonpath',\n",
+       "     'id': '953e1550-29df-4fda-9972-e3a7b65e8f25',\n",
+       "     'name': None,\n",
+       "     'description': None,\n",
+       "     'model_name': None,\n",
+       "     'branch_name': None,\n",
+       "     'commit_hash': None,\n",
+       "     'training_metadata': None,\n",
+       "     'tags': ['b'],\n",
+       "     'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298836),\n",
+       "     'feature': [{'name': 'f',\n",
+       "       'id': 'c86a3fa6-a4b8-4538-bc75-a5f588187060',\n",
+       "       'description': None,\n",
+       "       'importance': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298882)},\n",
+       "      {'name': 'g',\n",
+       "       'id': '0d2c1514-0420-459b-937e-8b4e707c5767',\n",
+       "       'description': None,\n",
+       "       'importance': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298950)},\n",
+       "      {'name': 'h',\n",
+       "       'id': 'dbc8e53b-e7ca-4357-8278-a96da8b0b4e6',\n",
+       "       'description': None,\n",
+       "       'importance': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298997)},\n",
+       "      {'name': 'i',\n",
+       "       'id': 'bc81ed11-8230-48b9-ba8a-68023248e055',\n",
+       "       'description': None,\n",
+       "       'importance': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299043)}],\n",
+       "     'parameter': [{'name': 'd',\n",
+       "       'id': 'b8ca802b-6a71-44de-9115-f4587e9ee10e',\n",
+       "       'value': 100,\n",
+       "       'description': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299094)},\n",
+       "      {'name': 'e',\n",
+       "       'id': '9025ac25-cc2d-40d6-9d18-b840bec595e1',\n",
+       "       'value': 1000,\n",
+       "       'description': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299160)},\n",
+       "      {'name': 'f',\n",
+       "       'id': '9da4f2dc-64fe-49eb-9a85-8c3d2c02567b',\n",
+       "       'value': 1000,\n",
+       "       'description': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299205)}],\n",
+       "     'metric': [{'name': 'j',\n",
+       "       'value': 0.0,\n",
+       "       'id': '8fd2207f-afbd-4065-b16c-0c40f15fb601',\n",
+       "       'description': None,\n",
+       "       'directionality': 'score',\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299253),\n",
+       "       'tags': ['l']},\n",
+       "      {'name': 'k',\n",
+       "       'value': 0.0,\n",
+       "       'id': '012f2095-f596-460a-bd74-c86d4d207ac8',\n",
+       "       'description': None,\n",
+       "       'directionality': 'score',\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299320),\n",
+       "       'tags': ['m']}],\n",
+       "     'artifact': [{'name': 'o',\n",
+       "       'id': '5e3ca3d0-1630-4879-8db8-5244715eedcc',\n",
+       "       'description': None,\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299368),\n",
+       "       'tags': [],\n",
+       "       'parent_id': '953e1550-29df-4fda-9972-e3a7b65e8f25'}],\n",
+       "     'dataframe': [{'id': 'b5ecb0d3-3f49-4c53-81d3-00beab46a265',\n",
+       "       'name': None,\n",
+       "       'description': None,\n",
+       "       'tags': [],\n",
+       "       'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299508),\n",
+       "       'parent_id': '953e1550-29df-4fda-9972-e3a7b65e8f25'}]}]}]}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from rubicon_ml import RubiconJSON\n",
+    "\n",
+    "pr_json = RubiconJSON(projects=pr)\n",
+    "pr_json.json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ae578ef",
+   "metadata": {},
+   "source": [
+    "### Demonstrating RubiconJSON search functionality\n",
+    "\n",
+    "#### Here we'll get the metrics from each experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "aabe1d29",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4 experiments\n",
+      "2 metrics\n",
+      "[{'name': 'j', 'value': 1.0, 'id': '89b243a6-6687-44ad-84d2-5e2fd920f99c', 'description': None, 'directionality': 'score', 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 296681), 'tags': ['n']}, {'name': 'k', 'value': 0.0, 'id': '608deb15-bfde-4830-9aee-5324689f2d7c', 'description': None, 'directionality': 'score', 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 296744), 'tags': ['l']}]\n",
+      "2 metrics\n",
+      "[{'name': 'j', 'value': 0.0, 'id': 'ad75fa80-864d-4f08-a144-0e7357464d4a', 'description': None, 'directionality': 'score', 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297664), 'tags': ['l']}, {'name': 'k', 'value': 0.0, 'id': '896626d1-f3cc-418d-b227-aabce774f83c', 'description': None, 'directionality': 'score', 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297724), 'tags': ['n']}]\n",
+      "2 metrics\n",
+      "[{'name': 'j', 'value': 1.0, 'id': '3ee54ec9-64f0-47e1-8549-cb41e1049480', 'description': None, 'directionality': 'score', 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298445), 'tags': ['n']}, {'name': 'k', 'value': 0.0, 'id': 'b4a00c05-f4a7-4633-ab1f-8fa031a8b8d8', 'description': None, 'directionality': 'score', 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298508), 'tags': ['m']}]\n",
+      "2 metrics\n",
+      "[{'name': 'j', 'value': 0.0, 'id': '8fd2207f-afbd-4065-b16c-0c40f15fb601', 'description': None, 'directionality': 'score', 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299253), 'tags': ['l']}, {'name': 'k', 'value': 0.0, 'id': '012f2095-f596-460a-bd74-c86d4d207ac8', 'description': None, 'directionality': 'score', 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299320), 'tags': ['m']}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "res = pr_json.search(\"$..experiment[*].metric\")\n",
+    "\n",
+    "print(f\"{len(res)} experiments\")\n",
+    "for match in res:\n",
+    "    print(f\"{len(match.value)} metrics\")\n",
+    "    print(match.value)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af33d3c2",
+   "metadata": {},
+   "source": [
+    "#### Now let's get all experiments with tag 'b'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "7dfee977",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 experiments\n",
+      "{'project_name': 'jsonpath', 'id': '953e1550-29df-4fda-9972-e3a7b65e8f25', 'name': None, 'description': None, 'model_name': None, 'branch_name': None, 'commit_hash': None, 'training_metadata': None, 'tags': ['b'], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298836), 'feature': [{'name': 'f', 'id': 'c86a3fa6-a4b8-4538-bc75-a5f588187060', 'description': None, 'importance': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298882)}, {'name': 'g', 'id': '0d2c1514-0420-459b-937e-8b4e707c5767', 'description': None, 'importance': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298950)}, {'name': 'h', 'id': 'dbc8e53b-e7ca-4357-8278-a96da8b0b4e6', 'description': None, 'importance': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298997)}, {'name': 'i', 'id': 'bc81ed11-8230-48b9-ba8a-68023248e055', 'description': None, 'importance': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299043)}], 'parameter': [{'name': 'd', 'id': 'b8ca802b-6a71-44de-9115-f4587e9ee10e', 'value': 100, 'description': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299094)}, {'name': 'e', 'id': '9025ac25-cc2d-40d6-9d18-b840bec595e1', 'value': 1000, 'description': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299160)}, {'name': 'f', 'id': '9da4f2dc-64fe-49eb-9a85-8c3d2c02567b', 'value': 1000, 'description': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299205)}], 'metric': [{'name': 'j', 'value': 0.0, 'id': '8fd2207f-afbd-4065-b16c-0c40f15fb601', 'description': None, 'directionality': 'score', 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299253), 'tags': ['l']}, {'name': 'k', 'value': 0.0, 'id': '012f2095-f596-460a-bd74-c86d4d207ac8', 'description': None, 'directionality': 'score', 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299320), 'tags': ['m']}], 'artifact': [{'name': 'o', 'id': '5e3ca3d0-1630-4879-8db8-5244715eedcc', 'description': None, 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299368), 'tags': [], 'parent_id': '953e1550-29df-4fda-9972-e3a7b65e8f25'}], 'dataframe': [{'id': 'b5ecb0d3-3f49-4c53-81d3-00beab46a265', 'name': None, 'description': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299508), 'parent_id': '953e1550-29df-4fda-9972-e3a7b65e8f25'}]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "res = pr_json.search(\"$..experiment[?(@.tags[*]=='b')]\")\n",
+    "\n",
+    "print(f\"{len(res)} experiments\")\n",
+    "for match in res:\n",
+    "    print(match.value)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ba47d49",
+   "metadata": {},
+   "source": [
+    "#### To narrow our scope let's get all metrics named 'j' with a value greater than 0.5 from each experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "2d043790",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 metrics\n",
+      "{'name': 'j', 'value': 1.0, 'id': '89b243a6-6687-44ad-84d2-5e2fd920f99c', 'description': None, 'directionality': 'score', 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 296681), 'tags': ['n']}\n",
+      "{'name': 'j', 'value': 1.0, 'id': '3ee54ec9-64f0-47e1-8549-cb41e1049480', 'description': None, 'directionality': 'score', 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298445), 'tags': ['n']}\n"
+     ]
+    }
+   ],
+   "source": [
+    "res = pr_json.search(\"$..experiment[*].metric[?(@.name=='j' & @.value>=0.5)]\")\n",
+    "\n",
+    "print(f\"{len(res)} metrics\")\n",
+    "for match in res:\n",
+    "    print(match.value)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e6f4bfd",
+   "metadata": {},
+   "source": [
+    "#### Now getting all experiments that contian a metric named 'j' with a value less than 0.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "76f1f370",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 experiments\n",
+      "{'project_name': 'jsonpath', 'id': 'cc1b8445-b67a-4007-a0bd-dbda2a56f8c5', 'name': None, 'description': None, 'model_name': None, 'branch_name': None, 'commit_hash': None, 'training_metadata': None, 'tags': ['a'], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297268), 'feature': [{'name': 'f', 'id': '8edfdcbe-29ff-4cad-afcf-25bb03e0eb3e', 'description': None, 'importance': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297317)}, {'name': 'g', 'id': '92890604-d1f2-4883-8957-14984417470b', 'description': None, 'importance': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297378)}, {'name': 'h', 'id': '7100bca1-2322-425f-a57e-65b12be7889d', 'description': None, 'importance': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297426)}, {'name': 'i', 'id': 'f7b7a878-10ca-4b2e-9ad2-1d19e7fdc12d', 'description': None, 'importance': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297472)}], 'parameter': [{'name': 'd', 'id': '26cfd40c-d215-4321-9339-890d943389b4', 'value': 100, 'description': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297517)}, {'name': 'e', 'id': 'a7e5526b-949b-464b-81ba-7b8f05465ae5', 'value': 1000, 'description': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297574)}, {'name': 'f', 'id': 'd1f24807-e8d5-4659-b604-666a877cdcc2', 'value': 1000, 'description': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297619)}], 'metric': [{'name': 'j', 'value': 0.0, 'id': 'ad75fa80-864d-4f08-a144-0e7357464d4a', 'description': None, 'directionality': 'score', 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297664), 'tags': ['l']}, {'name': 'k', 'value': 0.0, 'id': '896626d1-f3cc-418d-b227-aabce774f83c', 'description': None, 'directionality': 'score', 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297724), 'tags': ['n']}], 'artifact': [{'name': 'o', 'id': '93e1a1ab-cb74-4179-a9c8-2d0731c70fcb', 'description': None, 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297772), 'tags': [], 'parent_id': 'cc1b8445-b67a-4007-a0bd-dbda2a56f8c5'}], 'dataframe': [{'id': '576dda9a-0a4e-4b78-92a4-3e84a8ffc2dc', 'name': None, 'description': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 297911), 'parent_id': 'cc1b8445-b67a-4007-a0bd-dbda2a56f8c5'}]}\n",
+      "{'project_name': 'jsonpath', 'id': '953e1550-29df-4fda-9972-e3a7b65e8f25', 'name': None, 'description': None, 'model_name': None, 'branch_name': None, 'commit_hash': None, 'training_metadata': None, 'tags': ['b'], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298836), 'feature': [{'name': 'f', 'id': 'c86a3fa6-a4b8-4538-bc75-a5f588187060', 'description': None, 'importance': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298882)}, {'name': 'g', 'id': '0d2c1514-0420-459b-937e-8b4e707c5767', 'description': None, 'importance': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298950)}, {'name': 'h', 'id': 'dbc8e53b-e7ca-4357-8278-a96da8b0b4e6', 'description': None, 'importance': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 298997)}, {'name': 'i', 'id': 'bc81ed11-8230-48b9-ba8a-68023248e055', 'description': None, 'importance': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299043)}], 'parameter': [{'name': 'd', 'id': 'b8ca802b-6a71-44de-9115-f4587e9ee10e', 'value': 100, 'description': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299094)}, {'name': 'e', 'id': '9025ac25-cc2d-40d6-9d18-b840bec595e1', 'value': 1000, 'description': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299160)}, {'name': 'f', 'id': '9da4f2dc-64fe-49eb-9a85-8c3d2c02567b', 'value': 1000, 'description': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299205)}], 'metric': [{'name': 'j', 'value': 0.0, 'id': '8fd2207f-afbd-4065-b16c-0c40f15fb601', 'description': None, 'directionality': 'score', 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299253), 'tags': ['l']}, {'name': 'k', 'value': 0.0, 'id': '012f2095-f596-460a-bd74-c86d4d207ac8', 'description': None, 'directionality': 'score', 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299320), 'tags': ['m']}], 'artifact': [{'name': 'o', 'id': '5e3ca3d0-1630-4879-8db8-5244715eedcc', 'description': None, 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299368), 'tags': [], 'parent_id': '953e1550-29df-4fda-9972-e3a7b65e8f25'}], 'dataframe': [{'id': 'b5ecb0d3-3f49-4c53-81d3-00beab46a265', 'name': None, 'description': None, 'tags': [], 'created_at': datetime.datetime(2023, 1, 4, 21, 34, 44, 299508), 'parent_id': '953e1550-29df-4fda-9972-e3a7b65e8f25'}]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "res = pr_json.search(\"$..experiment[?(@.metric[?(@.name=='j')].value<=0.5)]\")\n",
+    "\n",
+    "print(f\"{len(res)} experiments\")\n",
+    "for match in res:\n",
+    "    print(match.value)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76e431bc",
+   "metadata": {},
+   "source": [
+    "### Returning `rubicon_ml` objects from `RubiconJSON` search\n",
+    "\n",
+    "We can specify the \"return_type\" parameter of `RubiconJSON`'s search method and return our query as `rubicon_ml` objects. That is we can retreive objects as `artifact`, `dataframe`, `experiment`, `feature`, `metric`, `parameter`, or `project` by setting \"return_type\" as \"artifact\", \"dataframe\", \"experiment\", \"feature\", \"metric\", \"parameter\", or \"project\", respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "2df18b2f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<rubicon_ml.client.metric.Metric at 0x160dbb6d0>,\n",
+       " <rubicon_ml.client.metric.Metric at 0x160dbb730>]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "res = pr_json.search(\"$..experiment[*].metric[?(@.name=='j' & @.value>=0.5)]\", return_type=\"metric\")\n",
+    "res"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "af4ca510",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "j 1.0\n",
+      "j 1.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "for m in res:\n",
+    "    print(m.name, m.value)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/rubicon_ml/__init__.py
+++ b/rubicon_ml/__init__.py
@@ -12,6 +12,7 @@ from rubicon_ml.client import (  # noqa: E402
     Parameter,
     Project,
     Rubicon,
+    RubiconJSON,
 )
 from rubicon_ml.client.utils.exception_handling import set_failure_mode  # noqa: E402
 from rubicon_ml.intake_rubicon.publish import publish  # noqa: E402
@@ -26,5 +27,6 @@ __all__ = [
     "Project",
     "publish",
     "Rubicon",
+    "RubiconJSON",
     "set_failure_mode",
 ]

--- a/rubicon_ml/client/rubicon_json.py
+++ b/rubicon_ml/client/rubicon_json.py
@@ -56,40 +56,77 @@ class RubiconJSON:
         return_objects = []
         if return_type == "artifact":
             for match in res:
-                for i in range(len(match.value)):
-                    return_objects.append(Artifact(DomainArtifact(**match.value[i]), NoOpParent()))
+                if isinstance(match.value, list):
+                    for i in range(len(match.value)):
+                        return_objects.append(
+                            Artifact(DomainArtifact(**match.value[i]), NoOpParent())
+                        )
+                else:
+                    return_objects.append(Artifact(DomainArtifact(**match.value), NoOpParent()))
         elif return_type == "dataframe":
             for match in res:
-                for i in range(len(match.value)):
-                    return_objects.append(
-                        Dataframe(DomainDataframe(**match.value[i]), NoOpParent())
-                    )
+                if isinstance(match.value, list):
+                    for i in range(len(match.value)):
+                        return_objects.append(
+                            Dataframe(DomainDataframe(**match.value[i]), NoOpParent())
+                        )
+                else:
+                    return_objects.append(Dataframe(DomainDataframe(**match.value), NoOpParent()))
         elif return_type == "experiment":
             for match in res:
-                for key in ["feature", "parameter", "metric", "artifact", "dataframe"]:
-                    if key in match.value:
-                        del match.value[key]
-                return_objects.append(Experiment(DomainExperiment(**match.value), NoOpParent()))
+                if isinstance(match.value, list):
+                    for i in range(len(match.value)):
+                        for key in ["feature", "parameter", "metric", "artifact", "dataframe"]:
+                            if key in match.value[i]:
+                                del match.value[i][key]
+                        return_objects.append(
+                            Experiment(DomainExperiment(**match.value[i]), NoOpParent())
+                        )
+                else:
+                    for key in ["feature", "parameter", "metric", "artifact", "dataframe"]:
+                        if key in match.value:
+                            del match.value[key]
+                    return_objects.append(Experiment(DomainExperiment(**match.value), NoOpParent()))
         elif return_type == "feature":
             for match in res:
-                for i in range(len(match.value)):
-                    return_objects.append(Feature(DomainFeature(**match.value[i]), NoOpParent()))
+                if isinstance(match.value, list):
+                    for i in range(len(match.value)):
+                        return_objects.append(
+                            Feature(DomainFeature(**match.value[i]), NoOpParent())
+                        )
+                else:
+                    return_objects.append(Feature(DomainFeature(**match.value), NoOpParent()))
         elif return_type == "metric":
             for match in res:
-                for i in range(len(match.value)):
-                    return_objects.append(Metric(DomainMetric(**match.value[i]), NoOpParent()))
+                if isinstance(match.value, list):
+                    for i in range(len(match.value)):
+                        return_objects.append(Metric(DomainMetric(**match.value[i]), NoOpParent()))
+                else:
+                    return_objects.append(Metric(DomainMetric(**match.value), NoOpParent()))
         elif return_type == "parameter":
             for match in res:
-                for i in range(len(match.value)):
-                    return_objects.append(
-                        Parameter(DomainParameter(**match.value[i]), NoOpParent())
-                    )
+                if isinstance(match.value, list):
+                    for i in range(len(match.value)):
+                        return_objects.append(
+                            Parameter(DomainParameter(**match.value[i]), NoOpParent())
+                        )
+                else:
+                    return_objects.append(Parameter(DomainParameter(**match.value), NoOpParent()))
         elif return_type == "project":
             for match in res:
-                for key in ["artifact", "dataframe", "experiment"]:
-                    if key in match.value:
-                        del match.value[key]
-                return_objects.append(Project(DomainProject(**match.value), NoOpParent()))
+                if isinstance(match.value, list):
+                    for i in range(len(match.value)):
+                        for key in ["artifact", "dataframe", "experiment"]:
+                            if key in match.value[i]:
+                                del match.value[i][key]
+                        return_objects.append(
+                            Project(DomainProject(**match.value[i]), NoOpParent())
+                        )
+                else:
+                    for key in ["artifact", "dataframe", "experiment"]:
+                        if key in match.value:
+                            del match.value[key]
+                    return_objects.append(Project(DomainProject(**match.value), NoOpParent()))
 
         return return_objects
 

--- a/rubicon_ml/client/rubicon_json.py
+++ b/rubicon_ml/client/rubicon_json.py
@@ -30,6 +30,18 @@ class NoOpParent:
 
 
 class RubiconJSON:
+    """
+    RubiconJSON is a converting class which converts top-level `rubicon_ml` objects,
+    `projects`, and `experiments` into a JSON structured dict for
+    JSONPath-like querying.
+
+    Parameters
+    ----------
+    rubicon_objects : rubicon.client.Rubicon or `list` of type rubicon.client.Rubicon
+    projects : rubicon.client.Project or `list` of type rubicon.client.Project
+    experiments : rubicon.client.Experiment or `list` of type rubicon.client.Experiment
+    """
+
     def __init__(self, rubicon_objects=None, projects=None, experiments=None):
         self._json = self._convert_to_json(rubicon_objects, projects, experiments)
 

--- a/rubicon_ml/client/rubicon_json.py
+++ b/rubicon_ml/client/rubicon_json.py
@@ -32,7 +32,7 @@ class NoOpParent:
 class RubiconJSON:
     """
     RubiconJSON is a converting class which converts top-level `rubicon_ml` objects,
-    `projects`, and `experiments` into a JSON structured dict for
+    `projects`, and `experiments` into a JSON structured `dict` for
     JSONPath-like querying.
 
     Parameters
@@ -46,6 +46,16 @@ class RubiconJSON:
         self._json = self._convert_to_json(rubicon_objects, projects, experiments)
 
     def search(self, query, return_type=None):
+        """
+        Query the JSON generated from the RubiconJSON instantiation in a JSONPath-like manner.
+        Can return queries as `rubicon_ml.client` objects by specifying return_type parameter.
+        Will return as JSON structured `dict` by default.
+
+        Parameters
+        ----------
+        query: JSONPath-like query
+        return_type: "artifact", "dataframe", "experiment", "feature", "metric", "parameter", or "project" (optional)
+        """
         if return_type is not None:
             return_type = return_type.lower()
             if return_type not in [


### PR DESCRIPTION
closes: #315 

---

## What
  * Creates docs notebook for new `RubiconJSON` class
  * Adds notebook to docs in **Tutorials** section
  * Adds docstrings for `RubiconJSON` and `RubiconJSON.search`
  * Adds `RubiconJSON` and `RubiconJSON.search` to **API reference**
  * Adds some type checking that was missing in `RubiconJSON.search` (revealed by error thrown when creating notebook)
  * Lifts `RubiconJSON` to top level `rubicon_ml` in `rubicon_ml/__init__.py`

## How to Test
  * Run Notebook cells
  * Run `python -m pytest tests/unit/client/test_rubicon_json_client.py`
  * Build docs locally and see that notebook is under **Tutorials** and `RubiconJSON` in **API Reference**
       * `conda activate rubicon-ml-docs`
       * `make html`
       * `open ./build/html/index.html`
