### PR TITLE
remove shap notebook dependencies and test

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -98,12 +98,8 @@ xfail_strict = True
 [edgetest.envs.core]
 python_version = 3.9
 deps = 
-	kaleido
-	matplotlib
-	numba>=0.56.2
 	palmerpenguins
 	Pillow
-	shap
 conda_install = 
 	dask
 	jupyterlab

--- a/tests/notebooks/test_notebooks.py
+++ b/tests/notebooks/test_notebooks.py
@@ -53,6 +53,7 @@ IGNORE_EXECUTE_NOTEBOOK_FILENAMES = [
     "classification.ipynb",
     "failure-modes.ipynb",
     "integration-prefect-workflows.ipynb",
+    "logging-feature-plots.ipynb",
     "visualizing-experiments.ipynb",
 ]
 EXECUTE_NOTEBOOK_FILENAMES = [


### PR DESCRIPTION
## What
  * the shap and numba dependencies in this notebook have been causing testing issue for a while now - removing them
    * edgetest is failing due to shap
    * we can't update to python 3.11 due to numba (#299)
