### PR TITLE
cast values to strings before visualizing

### DIFF
--- a/rubicon_ml/viz/experiments_table.py
+++ b/rubicon_ml/viz/experiments_table.py
@@ -257,12 +257,12 @@ class ExperimentsTable(VizBase):
                 show_columns.add("tags")
 
             for parameter in experiment.parameters():
-                experiment_record[parameter.name] = parameter.value
+                experiment_record[parameter.name] = str(parameter.value)
 
                 self.parameter_names.add(parameter.name)
 
             for metric in experiment.metrics():
-                experiment_record[metric.name] = metric.value
+                experiment_record[metric.name] = str(metric.value)
 
                 self.metric_names.add(metric.name)
 


### PR DESCRIPTION
closes: #341 

---

## What
  * casts metric and parameter values to strings before passing them to the dash table visualization
    * I'm pretty sure this same conversion is happening in the javascript, but it doesn't always work right so we're moving it to the python layer

## How to Test
  * run the existing visualization notebooks with the experiment table in them and make sure everything looks good
