### PR TITLE
config update

### DIFF
--- a/rubicon_ml/client/config.py
+++ b/rubicon_ml/client/config.py
@@ -59,7 +59,7 @@ class Config:
             raise ValueError(f"PERSISTENCE must be one of {self.PERSISTENCE_TYPES}.")
 
         root_dir = os.environ.get("ROOT_DIR", root_dir)
-        if root_dir is None and persistence != "memory":
+        if root_dir is None and persistence == "filesystem":
             raise ValueError("root_dir cannot be None.")
 
         if is_auto_git_enabled:

--- a/rubicon_ml/client/config.py
+++ b/rubicon_ml/client/config.py
@@ -77,6 +77,8 @@ class Config:
             else:
                 return "local"
 
+        return "custom"  # catch-all for external backends
+
     def _get_repository(self):
         """Get the repository for the configured persistence type."""
         protocol = self._get_protocol()

--- a/rubicon_ml/repository/base.py
+++ b/rubicon_ml/repository/base.py
@@ -83,14 +83,14 @@ class BaseRepository:
 
         To be implemented by extensions of the base filesystem.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def _persist_domain(self, domain, path):
         """Write a domain object to the filesystem.
 
         To be implemented by extensions of the base filesystem.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def _read_bytes(self, path, err_msg=None):
         """Read bytes from the file at `path`."""


### PR DESCRIPTION
## What
  * inverts the second clause of the conditional `root_dir is None and persistence != "memory"` to `root_dir is None and persistence == "filesystem"`
    * `root_dir` not being None is only relevant to the "filesystem" backend, so base conditional on that
  * return default string from `_get_protocol` instead of None for external backends

## How to Test
  * verify existing tests still pass: `python -m pytest`
