### PR TITLE
added read/write for experiment archives

### DIFF
--- a/rubicon_ml/client/config.py
+++ b/rubicon_ml/client/config.py
@@ -59,7 +59,7 @@ class Config:
             raise ValueError(f"PERSISTENCE must be one of {self.PERSISTENCE_TYPES}.")
 
         root_dir = os.environ.get("ROOT_DIR", root_dir)
-        if root_dir is None and persistence != "memory":
+        if root_dir is None and persistence == "filesystem":
             raise ValueError("root_dir cannot be None.")
 
         if is_auto_git_enabled:
@@ -76,6 +76,8 @@ class Config:
                 return "s3"
             else:
                 return "local"
+
+        return "custom"  # catch-all for external backends
 
     def _get_repository(self):
         """Get the repository for the configured persistence type."""

--- a/rubicon_ml/client/project.py
+++ b/rubicon_ml/client/project.py
@@ -395,47 +395,6 @@ class Project(Base, ArtifactMixin, DataframeMixin):
         else:
             print("zip archive not created")
 
-    # @failsafe
-    # def experiments_from_archive(self, local_root:str, latest_only: Optional[bool]=False):
-    #     if os.path.exists(os.path.join(local_root, self.name)) == False:
-    #         self.repository._mkdir(os.path.join(local_root, self.name))
-
-    #     root_dir = self.repository.root_dir
-    #     shutil.copy(os.path.join(root_dir, self.name,"metadata.json"), os.path.join(local_root, self.name))
-
-    #     archive_dir = os.path.join(root_dir, self.name, "archives")
-    #     dest_experiments_dir = os.path.join(local_root, self.name, "experiments")
-
-    #     if os.path.exists(dest_experiments_dir) == False:
-    #         self.repository._mkdir(dest_experiments_dir)
-
-    #     dest_experiments_dir_mod_time = os.path.getmtime(dest_experiments_dir)
-    #     if os.path.exists(os.path.join(local_root, self.name)) == False:
-    #         self.repository._mkdir(os.path.join(local_root, self.name))
-
-    #     shutil.copy(os.path.join(root_dir, self.name,"metadata.json"), os.path.join(local_root, self.name))
-
-    #     if not latest_only:
-    #         for zip_archive_name in os.listdir(archive_dir):
-    #             zip_archive_filepath = os.path.join(archive_dir, zip_archive_name)
-    #             with ZipFile(zip_archive_filepath, 'r') as curr_archive:
-    #                 curr_archive.extractall(dest_experiments_dir)
-    #     else:
-    #         latest_zip_archive = None
-    #         latest_time = 0
-    #         for zip_archive in os.scandir(archive_dir):
-    #             mod_time = zip_archive.stat().st_mtime_ns
-    #             if mod_time > latest_time:
-    #                 latest_zip_archive = zip_archive
-    #                 latest_time = mod_time
-    #         with ZipFile(latest_zip_archive, 'r') as zip_archive:
-    #             zip_archive.extractall(dest_experiments_dir)
-
-    #     if os.path.getmtime(dest_experiments_dir) > dest_experiments_dir_mod_time:
-    #         print("experiments read from archive")
-    #     else:
-    #         print("experiments not read from archive")
-
     @failsafe
     def experiments_from_archive(self, remote_root: str, latest_only: Optional[bool] = False):
         root_dir = self.repository.root_dir

--- a/rubicon_ml/client/project.py
+++ b/rubicon_ml/client/project.py
@@ -407,6 +407,15 @@ class Project(Base, ArtifactMixin, DataframeMixin):
 
     @failsafe
     def experiments_from_archive(self, remote_root: str, latest_only: Optional[bool] = False):
+        """Retrieve archived experiments into this project.
+        Parameters
+        ----------
+        remote_root : str or pathlike object
+            The remote root of the repository with archived experiments to read in
+        latest_only : bool, optional
+            Indicates whether or not experiments should only be read from the latest archive
+
+        """
         root_dir = self.repository.root_dir
         shutil.copy(
             os.path.join(remote_root, self.name, "metadata.json"), os.path.join(root_dir, self.name)

--- a/rubicon_ml/client/project.py
+++ b/rubicon_ml/client/project.py
@@ -447,14 +447,14 @@ class Project(Base, ArtifactMixin, DataframeMixin):
             for zip_archive in self.repository._ls(archive_dir):
                 zip_archive_filepath = os.path.join(archive_dir, zip_archive)
                 mod_time = self.repository._modified(zip_archive_filepath)
-                print(mod_time, latest_time)
+                print(mod_time, latest_time, latest_zip_archive_filepath)
                 if latest_time is None:
                     latest_time = mod_time
                     latest_zip_archive_filepath = zip_archive_filepath
                 elif mod_time > latest_time:
                     latest_zip_archive_filepath = zip_archive_filepath
                     latest_time = mod_time
-                print(latest_zip_archive_filepath)
+                print(mod_time, latest_time, latest_zip_archive_filepath)
             with ZipFile(latest_zip_archive_filepath, "r") as zip_archive:
                 zip_archive.extractall(dest_experiments_dir)
 

--- a/rubicon_ml/client/project.py
+++ b/rubicon_ml/client/project.py
@@ -447,14 +447,12 @@ class Project(Base, ArtifactMixin, DataframeMixin):
             for zip_archive in self.repository._ls(archive_dir):
                 zip_archive_filepath = os.path.join(archive_dir, zip_archive)
                 mod_time = self.repository._modified(zip_archive_filepath)
-                print(mod_time, latest_time, latest_zip_archive_filepath)
                 if latest_time is None:
                     latest_time = mod_time
                     latest_zip_archive_filepath = zip_archive_filepath
                 elif mod_time > latest_time:
                     latest_zip_archive_filepath = zip_archive_filepath
                     latest_time = mod_time
-                print(mod_time, latest_time, latest_zip_archive_filepath)
             with ZipFile(latest_zip_archive_filepath, "r") as zip_archive:
                 zip_archive.extractall(dest_experiments_dir)
 

--- a/rubicon_ml/client/project.py
+++ b/rubicon_ml/client/project.py
@@ -360,10 +360,14 @@ class Project(Base, ArtifactMixin, DataframeMixin):
         Parameters
         ----------
         experiments : list of Experiments, optional
-            The rubicon.client.Experiment objects to archive. If None all logged experiments are archived.
+            The rubicon.client.Experiment objects to archive.
+            If None all logged experiments are archived.
         remote_root : str or pathlike object, optional
             The remote root of the repository to archive to
 
+        Returns
+        -------
+        filepath of newly created archive
         """
         if len(self.experiments()) == 0:
             raise ValueError("`project` has no logged `experiments` to archive")
@@ -414,7 +418,6 @@ class Project(Base, ArtifactMixin, DataframeMixin):
             The remote root of the repository with archived experiments to read in
         latest_only : bool, optional
             Indicates whether or not experiments should only be read from the latest archive
-
         """
         root_dir = self.repository.root_dir
         shutil.copy(

--- a/rubicon_ml/client/project.py
+++ b/rubicon_ml/client/project.py
@@ -412,7 +412,7 @@ class Project(Base, ArtifactMixin, DataframeMixin):
 
     @failsafe
     def experiments_from_archive(self, remote_root: str, latest_only: Optional[bool] = False):
-        """Retrieve archived experiments into this project.
+        """Retrieve archived experiments into this project's experiments folder.
 
         Parameters
         ----------

--- a/rubicon_ml/repository/base.py
+++ b/rubicon_ml/repository/base.py
@@ -83,14 +83,14 @@ class BaseRepository:
 
         To be implemented by extensions of the base filesystem.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def _persist_domain(self, domain, path):
         """Write a domain object to the filesystem.
 
         To be implemented by extensions of the base filesystem.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def _read_bytes(self, path, err_msg=None):
         """Read bytes from the file at `path`."""

--- a/rubicon_ml/repository/base.py
+++ b/rubicon_ml/repository/base.py
@@ -74,9 +74,15 @@ class BaseRepository:
 
         return directories
 
+    def _ls(self, path):
+        return self.filesystem.ls(path)
+
     def _mkdir(self, dirpath):
         """Creates a directory `dirpath` with parents."""
         return self.filesystem.mkdir(dirpath, parents=True, exist_ok=True)
+
+    def _modified(self, path):
+        return self.filesystem.modified(path)
 
     def _persist_bytes(self, bytes_data, path):
         """Write bytes to the filesystem.

--- a/tests/unit/client/test_project_client.py
+++ b/tests/unit/client/test_project_client.py
@@ -1,4 +1,5 @@
 import os
+import time
 import warnings
 from unittest import mock
 
@@ -407,6 +408,7 @@ def test_experiments_from_archive_latest_only():
 
     experiment6 = projectA.log_experiment(name="experiment6")
     experiment7 = projectA.log_experiment(name="experiment7")
+    time.sleep(1)
     projectA.archive([experiment6, experiment7])
 
     experiments_dirB = os.path.join(root_dirB, slugify(projectB.name), "experiments")

--- a/tests/unit/client/test_project_client.py
+++ b/tests/unit/client/test_project_client.py
@@ -317,9 +317,7 @@ def test_archive_remote_root():
     projectB = rubiconB.get_or_create_project("ArchiveTesting")
     projectB.log_experiment(name="experiment1")
     projectB.log_experiment(name="experiment2")
-    zip_archive_filename = projectB.archive(
-        remote_root=os.path.join(os.path.dirname(os.path.realpath(__file__)), "rubiconA")
-    )
+    zip_archive_filename = projectB.archive(remote_root=os.path.dirname(os.path.realpath(__file__)))
 
     assert projectA.repository._exists(zip_archive_filename)
 
@@ -344,9 +342,7 @@ def test_experiments_from_archive_bad_argument():
 
     projectB = rubiconB.get_or_create_project("ArchiveTesting")
     with pytest.raises(ValueError):
-        projectB.experiments_from_archive(
-            remote_root=os.path.join(os.path.dirname(os.path.realpath(__file__)), "rubiconA")
-        )
+        projectB.experiments_from_archive(remote_root=projectA.repository.root_dir)
     rubiconA.repository.filesystem.rm(rubiconA.config.root_dir, recursive=True)
     rubiconB.repository.filesystem.rm(rubiconB.config.root_dir, recursive=True)
 

--- a/tests/unit/client/test_project_client.py
+++ b/tests/unit/client/test_project_client.py
@@ -1,3 +1,4 @@
+import os
 import warnings
 from unittest import mock
 
@@ -262,3 +263,162 @@ def test_to_df_grouped_by_invalid_group(rubicon_and_project_client_with_experime
         project.to_df(group_by="INVALID")
 
     assert "`group_by` must be one of" in str(e)
+
+
+def test_archive_no_experiments(project_client):
+    project = project_client
+    with pytest.raises(ValueError):
+        project.archive()
+
+
+def test_archive_bad_argument(project_client):
+    project = project_client
+    experiment1 = project.log_experiment(name="experiment1")
+    with pytest.raises(ValueError):
+        project.archive(experiment1)
+
+    project.log_experiment(name="experiment2")
+    with pytest.raises(ValueError):
+        project.archive(["experiment1", "experiment2"])
+
+
+def test_archive_all_experiments(rubicon_local_filesystem_client_with_project):
+    project = rubicon_local_filesystem_client_with_project[1]
+    project.log_experiment(name="experiment1")
+    project.log_experiment(name="experiment2")
+    project.log_experiment(name="experiment3")
+    archive_path = project.archive()
+
+    assert project.repository._exists(archive_path)
+
+
+def test_archive_select_experiments(rubicon_local_filesystem_client_with_project):
+    project = rubicon_local_filesystem_client_with_project[1]
+    experiment1 = project.log_experiment(name="experiment1")
+    experiment2 = project.log_experiment(name="experiment2")
+    project.log_experiment(name="experiment3")
+    zip_archive_filename = project.archive([experiment1, experiment2])
+
+    assert project.repository._exists(zip_archive_filename)
+
+
+def test_archive_remote_root():
+    rubiconA = Rubicon(
+        persistence="filesystem",
+        root_dir=os.path.join(os.path.dirname(os.path.realpath(__file__)), "rubiconA"),
+    )
+
+    rubiconB = Rubicon(
+        persistence="filesystem",
+        root_dir=os.path.join(os.path.dirname(os.path.realpath(__file__)), "rubiconB"),
+    )
+
+    projectA = rubiconA.get_or_create_project("ArchiveTesting")
+    projectB = rubiconB.get_or_create_project("ArchiveTesting")
+    projectB.log_experiment(name="experiment1")
+    projectB.log_experiment(name="experiment2")
+    zip_archive_filename = projectB.archive(
+        remote_root=os.path.join(os.path.dirname(os.path.realpath(__file__)), "rubiconA")
+    )
+
+    assert projectA.repository._exists(zip_archive_filename)
+
+    rubiconA.repository.filesystem.rm(rubiconA.config.root_dir, recursive=True)
+    rubiconB.repository.filesystem.rm(rubiconB.config.root_dir, recursive=True)
+
+
+def test_experiments_from_archive_bad_argument():
+    rubiconA = Rubicon(
+        persistence="filesystem",
+        root_dir=os.path.join(os.path.dirname(os.path.realpath(__file__)), "rubiconA"),
+    )
+
+    rubiconB = Rubicon(
+        persistence="filesystem",
+        root_dir=os.path.join(os.path.dirname(os.path.realpath(__file__)), "rubiconB"),
+    )
+    projectA = rubiconA.get_or_create_project("ArchiveTesting")
+    projectA.log_experiment(name="experiment1")
+    projectA.log_experiment(name="experiment2")
+    # no archive created
+
+    projectB = rubiconB.get_or_create_project("ArchiveTesting")
+    with pytest.raises(ValueError):
+        projectB.experiments_from_archive(
+            remote_root=os.path.join(os.path.dirname(os.path.realpath(__file__)), "rubiconA")
+        )
+    rubiconA.repository.filesystem.rm(rubiconA.config.root_dir, recursive=True)
+    rubiconB.repository.filesystem.rm(rubiconB.config.root_dir, recursive=True)
+
+
+def test_experiments_from_archive():
+    root_dirA = os.path.join(os.path.dirname(os.path.realpath(__file__)), "rubiconA")
+    rubiconA = Rubicon(
+        persistence="filesystem",
+        root_dir=root_dirA,
+    )
+
+    root_dirB = os.path.join(os.path.dirname(os.path.realpath(__file__)), "rubiconB")
+    rubiconB = Rubicon(
+        persistence="filesystem",
+        root_dir=root_dirB,
+    )
+
+    projectA = rubiconA.get_or_create_project("ArchiveTesting")
+    projectA.log_experiment(name="experiment1")
+    projectA.log_experiment(name="experiment2")
+    projectA.archive()
+
+    projectB = rubiconB.get_or_create_project("ArchiveTesting")
+    projectB.log_experiment(name="experiment3")
+    projectB.log_experiment(name="experiment4")
+
+    experiments_dirB = os.path.join(root_dirB, "ArchiveTesting", "experiments")
+    og_num_exps_B = len(projectB.repository._ls(experiments_dirB))
+    assert og_num_exps_B == 2
+
+    projectB.experiments_from_archive(remote_root=root_dirA)
+
+    new_num_expsB = len(projectB.repository._ls(experiments_dirB))
+    assert new_num_expsB == 4
+    rubiconA.repository.filesystem.rm(rubiconA.config.root_dir, recursive=True)
+    rubiconB.repository.filesystem.rm(rubiconB.config.root_dir, recursive=True)
+
+
+def test_experiments_from_archive_latest_only():
+    root_dirA = os.path.join(os.path.dirname(os.path.realpath(__file__)), "rubiconA")
+    rubiconA = Rubicon(
+        persistence="filesystem",
+        root_dir=root_dirA,
+    )
+
+    root_dirB = os.path.join(os.path.dirname(os.path.realpath(__file__)), "rubiconB")
+    rubiconB = Rubicon(
+        persistence="filesystem",
+        root_dir=root_dirB,
+    )
+
+    projectA = rubiconA.get_or_create_project("ArchiveTesting")
+    projectA.log_experiment(name="experiment1")
+    projectA.log_experiment(name="experiment2")
+    projectA.log_experiment(name="experiment3")
+    projectA.archive()
+
+    projectB = rubiconB.get_or_create_project("ArchiveTesting")
+    projectB.log_experiment(name="experiment4")
+    projectB.log_experiment(name="experiment5")
+
+    experiment6 = projectA.log_experiment(name="experiment6")
+    experiment7 = projectA.log_experiment(name="experiment7")
+    projectA.archive([experiment6, experiment7])
+
+    experiments_dirB = os.path.join(root_dirB, "ArchiveTesting", "experiments")
+    og_num_exps_B = len(projectB.repository._ls(experiments_dirB))
+    assert og_num_exps_B == 2
+
+    projectB.experiments_from_archive(remote_root=root_dirA, latest_only=True)
+
+    new_num_expsB = len(projectB.repository._ls(experiments_dirB))
+    assert new_num_expsB == 4
+    rubiconA.repository.filesystem.rm(rubiconA.config.root_dir, recursive=True)
+    rubiconB.repository.filesystem.rm(rubiconB.config.root_dir, recursive=True)

--- a/tests/unit/client/test_project_client.py
+++ b/tests/unit/client/test_project_client.py
@@ -7,6 +7,7 @@ import pytest
 from rubicon_ml import domain
 from rubicon_ml.client import Project, Rubicon
 from rubicon_ml.exceptions import RubiconException
+from rubicon_ml.repository.utils import slugify
 
 
 class MockCompletedProcess:
@@ -369,7 +370,7 @@ def test_experiments_from_archive():
     projectB.log_experiment(name="experiment3")
     projectB.log_experiment(name="experiment4")
 
-    experiments_dirB = os.path.join(root_dirB, "ArchiveTesting", "experiments")
+    experiments_dirB = os.path.join(root_dirB, slugify(projectB.name), "experiments")
     og_num_exps_B = len(projectB.repository._ls(experiments_dirB))
     assert og_num_exps_B == 2
 
@@ -408,7 +409,7 @@ def test_experiments_from_archive_latest_only():
     experiment7 = projectA.log_experiment(name="experiment7")
     projectA.archive([experiment6, experiment7])
 
-    experiments_dirB = os.path.join(root_dirB, "ArchiveTesting", "experiments")
+    experiments_dirB = os.path.join(root_dirB, slugify(projectB.name), "experiments")
     og_num_exps_B = len(projectB.repository._ls(experiments_dirB))
     assert og_num_exps_B == 2
 


### PR DESCRIPTION
Adresses: #346 and #347 

---

## What
  * Implements archival of logged experiments in a `project` (write)
  * Implements retrieval of archived experiments from a "remote" archive (read)
  * Adds some helpful methods to the `BaseRepository`
  * Adds tests

## How to Test
  * python -m pytest tests/unit/client/test_project_client.py
  * Or run the following cells in a Jupyter notebook (within rubicon-ml-dev environment).
```
from rubicon_ml import Rubicon
```
```
rubiconA = Rubicon(persistence="filesystem", root_dir='rubicon-rootA')
projectA = rubiconA.get_or_create_project("ArchiveTesting")
experiment1 = projectA.log_experiment(name="experiment1")
experiment2 = projectA.log_experiment(name="experiment2")
projectA.archive()
```
```
rubiconB = Rubicon(persistence="filesystem", root_dir='rubicon-rootB')
projectB = rubiconB.get_or_create_project("ArchiveTesting")
```
```
projectB.experiments_from_archive(remote_root="rubicon-rootA")
```
```
! ls './rubicon-rootB/ArchiveTesting'
```
```
! ls './rubicon-rootB/ArchiveTesting/experiments'
```
