### PR TITLE
`root_dir` as kwarg

### DIFF
--- a/rubicon_ml/client/config.py
+++ b/rubicon_ml/client/config.py
@@ -93,4 +93,4 @@ class Config:
                 + f"`protocol` (from `root_dir`): {protocol}"
             )
 
-        return repository(self.root_dir, **self.storage_options)
+        return repository(root_dir=self.root_dir, **self.storage_options)


### PR DESCRIPTION
## What
  * instantiate repositories with `root_dir` as a kwarg
    * necessary for custom backends that do not require `root_dir`

## How to Test
  * `python -m pytest`
