### PR TITLE
Input Remote Rubicon to Zip Archiving 

### DIFF
--- a/rubicon_ml/client/project.py
+++ b/rubicon_ml/client/project.py
@@ -356,8 +356,8 @@ class Project(Base, ArtifactMixin, DataframeMixin):
         ----------
         experiments : list of Experiments, optional
             The rubicon.client.Experiment objects to archive. If None all logged experiments are archived.
-        remote_root : str or pathlike object, optional
-            The remote root of the repository to archive to
+        remote_rubicon : rubicon_ml.Rubicon object, optional
+            The remote Rubicon object with the repository to archive to
 
         Returns
         -------
@@ -391,8 +391,8 @@ class Project(Base, ArtifactMixin, DataframeMixin):
 
         Parameters
         ----------
-        remote_root : str or pathlike object
-            The remote root of the repository with archived experiments to read in
+        remote_rubicon : rubicon_ml.Rubicon object
+            The remote Rubicon object with the repository containing archived experiments to read in
         latest_only : bool, optional
             Indicates whether or not experiments should only be read from the latest archive
         """

--- a/rubicon_ml/repository/base.py
+++ b/rubicon_ml/repository/base.py
@@ -285,6 +285,8 @@ class BaseRepository:
 
         Parameters
         ----------
+        project_name : str
+            Name of the calling project (project to create archive for)
         experiments : list of Experiments, optional
             The rubicon.client.Experiment objects to archive. If None all logged experiments are archived.
         remote_rubicon_root : str or pathlike object, optional
@@ -327,6 +329,17 @@ class BaseRepository:
     def _experiments_from_archive(
         self, project_name, remote_rubicon_root: str, latest_only: Optional[bool] = False
     ):
+        """Retrieve archived experiments into this project's experiments folder.
+
+        Parameters
+        ----------
+        project_name : str
+            Name of the calling project (project to read experiments into)
+        remote_rubicon_root : str or pathlike object
+            The remote Rubicon object with the repository containing archived experiments to read in
+        latest_only : bool, optional
+            Indicates whether or not experiments should only be read from the latest archive
+        """
         root_dir = self.root_dir
         shutil.copy(
             os.path.join(remote_rubicon_root, slugify(project_name), "metadata.json"),

--- a/rubicon_ml/repository/base.py
+++ b/rubicon_ml/repository/base.py
@@ -276,7 +276,10 @@ class BaseRepository:
     # ------- Archiving --------
 
     def _archive(
-        self, project_name, experiments: Optional[List] = None, remote_root: Optional[str] = None
+        self,
+        project_name,
+        experiments: Optional[List] = None,
+        remote_rubicon_root: Optional[str] = None,
     ):
         """Archive the experiments logged to this project.
 
@@ -284,15 +287,15 @@ class BaseRepository:
         ----------
         experiments : list of Experiments, optional
             The rubicon.client.Experiment objects to archive. If None all logged experiments are archived.
-        remote_root : str or pathlike object, optional
+        remote_rubicon_root : str or pathlike object, optional
             The remote root of the repository to archive to
 
         Returns
         -------
         filepath of newly created archive
         """
-        if remote_root is not None:
-            archive_dir = os.path.join(remote_root, slugify(project_name), "archives")
+        if remote_rubicon_root is not None:
+            archive_dir = os.path.join(remote_rubicon_root, slugify(project_name), "archives")
         else:
             archive_dir = os.path.join(self.root_dir, slugify(project_name), "archives")
 
@@ -322,16 +325,16 @@ class BaseRepository:
         return zip_archive_filename
 
     def _experiments_from_archive(
-        self, project_name, remote_root: str, latest_only: Optional[bool] = False
+        self, project_name, remote_rubicon_root: str, latest_only: Optional[bool] = False
     ):
         root_dir = self.root_dir
         shutil.copy(
-            os.path.join(remote_root, slugify(project_name), "metadata.json"),
+            os.path.join(remote_rubicon_root, slugify(project_name), "metadata.json"),
             os.path.join(root_dir, slugify(project_name)),
         )
-        archive_dir = os.path.join(remote_root, slugify(project_name), "archives")
+        archive_dir = os.path.join(remote_rubicon_root, slugify(project_name), "archives")
         if not self._exists(archive_dir):
-            raise ValueError("`remote_root` has no archives")
+            raise ValueError("`remote_rubicon_root` has no archives")
 
         dest_experiments_dir = self._get_experiment_metadata_root(project_name)
         if not self._exists(dest_experiments_dir):


### PR DESCRIPTION
## What
  * Updates zip archiving to take in `remote_rubicon` objects (`rubicon_ml.Rubicon`) instead of `remote_root` string
  * Adds necessary input validation
  * Updates refactored repository code to reflect change
  * Updates tests

## How to Test
  * `python -m pytest tests/unit/client/test_project_client.py`
