### PR TITLE
remove conda from edgetest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -98,15 +98,14 @@ xfail_strict = True
 [edgetest.envs.core]
 python_version = 3.9
 deps = 
-	kaleido
-	palmerpenguins
-	Pillow
-conda_install = 
 	dask
 	jupyterlab
+	kaleido
 	nodejs
 	nbconvert
 	nbformat
+	palmerpenguins
+	Pillow
 	pytest
 	pytest-cov
 	prefect


### PR DESCRIPTION
## What
  * fixes the issues we've been having with nightly edgetest runs
    * moves the dependencies in the `conda_install` section into `deps` to just install them with `pip`

## How to Test
  * https://github.com/capitalone/rubicon-ml/actions/runs/5148369446
