### PR TITLE
added multiple-backend example notebook + docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -122,6 +122,7 @@ To install all extra modules, use the ``all`` extra.
    logging-examples/logging-plots
    logging-examples/logging-concurrently
    logging-examples/tagging
+   logging-examples/multiple-backend
    visualizations.rst
 
 .. toctree::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -134,8 +134,8 @@ To install all extra modules, use the ``all`` extra.
    integrations/integration-prefect-workflows
    integrations/integration-sklearn
    logging-examples/logging-feature-plots
-   logging-examples/visualizing-logged-dataframes
    logging-examples/multiple-backend
+   logging-examples/visualizing-logged-dataframes
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -122,7 +122,6 @@ To install all extra modules, use the ``all`` extra.
    logging-examples/logging-plots
    logging-examples/logging-concurrently
    logging-examples/tagging
-   logging-examples/multiple-backend
    visualizations.rst
 
 .. toctree::
@@ -136,6 +135,7 @@ To install all extra modules, use the ``all`` extra.
    integrations/integration-sklearn
    logging-examples/logging-feature-plots
    logging-examples/visualizing-logged-dataframes
+   logging-examples/multiple-backend
 
 .. toctree::
    :maxdepth: 2

--- a/notebooks/logging-examples/multiple-backend.ipynb
+++ b/notebooks/logging-examples/multiple-backend.ipynb
@@ -5,7 +5,7 @@
    "id": "d39383f7",
    "metadata": {},
    "source": [
-    "# Multiple Backend\n",
+    "# Log with Multiple Backends\n",
     "`rubicon-ml` allows users to instantiate `Rubicon` objects with multiple backends to write to/read from. These backends include local, memory, and S3 repositories. Here's a walk through of how one might instantiate and use a `Rubicon` object with multiple backends."
    ]
   },

--- a/notebooks/logging-examples/multiple-backend.ipynb
+++ b/notebooks/logging-examples/multiple-backend.ipynb
@@ -1,0 +1,314 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d39383f7",
+   "metadata": {},
+   "source": [
+    "# Multiple Backend\n",
+    "`rubicon-ml` allows users to instantiate `Rubicon` objects with multiple backends to write to/read from. These backends include local, memory, and S3 repositories. Here's a walk through of how one might instantiate and use a `Rubicon` object with multiple backends."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "7e1d5aaa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rubicon_ml import Rubicon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e38b0be9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#rb = Rubicon(persistence=\"memory\")\n",
+    "#or\n",
+    "#rb = Rubicon(persistence=\"filesystem\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1936248",
+   "metadata": {},
+   "source": [
+    "However, when we want multiple backends we utilize the `composite_config` kwarg:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "095655e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#example multiple backend instantiaiton\n",
+    "rb = Rubicon(composite_config=[\n",
+    "    {\"persistence\": \"filesystem\", \"root_dir\": \"./local/rootA\"},\n",
+    "    {\"persistence\": \"filesystem\", \"root_dir\": \"./local/rootB\"},\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66644d33",
+   "metadata": {},
+   "source": [
+    "### Write Commands\n",
+    "The following commands write to all insantiated backend repositories:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b7ecf19d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project = rb.create_project(\"example_project\")\n",
+    "\n",
+    "experiment = project.log_experiment(\"example_experiment\")\n",
+    "\n",
+    "artifact = experiment.log_artifact(data_bytes=b\"bytes\", name=\"example_artifact\")\n",
+    "import pandas as pd\n",
+    "dataframe = experiment.log_dataframe(pd.DataFrame([[5, 0, 0], [0, 5, 1], [0, 0, 4]], columns=[\"x\", \"y\", \"z\"]))\n",
+    "feature = experiment.log_feature(\"year\")\n",
+    "metric = experiment.log_metric(\"accuracy\", .8)\n",
+    "parameter = experiment.log_parameter(\"n_estimators\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10db7e8b",
+   "metadata": {},
+   "source": [
+    "Let's verify both of our backends have been written to:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c9e815cf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1m\u001b[36mexampleproject\u001b[m\u001b[m\n",
+      "\n",
+      "\n",
+      "\u001b[1m\u001b[36mexperiments\u001b[m\u001b[m   metadata.json\n",
+      "\n",
+      "\n",
+      "\u001b[1m\u001b[36m3cd4155e-08e3-4ae0-9c63-3566334d9a5e\u001b[m\u001b[m\n",
+      "\n",
+      "\n",
+      "\u001b[1m\u001b[36martifacts\u001b[m\u001b[m     \u001b[1m\u001b[36mfeatures\u001b[m\u001b[m      \u001b[1m\u001b[36mmetrics\u001b[m\u001b[m\n",
+      "\u001b[1m\u001b[36mdataframes\u001b[m\u001b[m    metadata.json \u001b[1m\u001b[36mparameters\u001b[m\u001b[m\n",
+      "\n",
+      "\n",
+      "\u001b[1m\u001b[36maf003e41-6278-412c-8511-ccfbc2813cf3\u001b[m\u001b[m\n",
+      "\n",
+      "\n",
+      "\u001b[1m\u001b[36mc241e0c6-ce22-49fd-9555-7e73ba16e63d\u001b[m\u001b[m\n",
+      "\n",
+      "\n",
+      "\u001b[1m\u001b[36myear\u001b[m\u001b[m\n",
+      "\n",
+      "\n",
+      "\u001b[1m\u001b[36maccuracy\u001b[m\u001b[m\n",
+      "\n",
+      "\n",
+      "\u001b[1m\u001b[36mnestimators\u001b[m\u001b[m\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ls \"./local/rootA\"\n",
+    "print(\"\\n\")\n",
+    "!ls \"./local/rootA/exampleproject\"\n",
+    "print(\"\\n\")\n",
+    "!ls \"./local/rootA/exampleproject/experiments\"\n",
+    "print(\"\\n\")\n",
+    "!ls \"./local/rootA/exampleproject/experiments/{experiment.id}\" \n",
+    "print(\"\\n\")\n",
+    "!ls \"./local/rootA/exampleproject/experiments/{experiment.id}/artifacts\"\n",
+    "print(\"\\n\")\n",
+    "!ls \"./local/rootA/exampleproject/experiments/{experiment.id}/dataframes\"\n",
+    "print(\"\\n\")\n",
+    "!ls \"./local/rootA/exampleproject/experiments/{experiment.id}/features\"\n",
+    "print(\"\\n\")\n",
+    "!ls \"./local/rootA/exampleproject/experiments/{experiment.id}/metrics\"\n",
+    "print(\"\\n\")\n",
+    "!ls \"./local/rootA/exampleproject/experiments/{experiment.id}/parameters\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d95347c9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1m\u001b[36mexampleproject\u001b[m\u001b[m\n",
+      "\n",
+      "\n",
+      "\u001b[1m\u001b[36mexperiments\u001b[m\u001b[m   metadata.json\n",
+      "\n",
+      "\n",
+      "\u001b[1m\u001b[36m3cd4155e-08e3-4ae0-9c63-3566334d9a5e\u001b[m\u001b[m\n",
+      "\n",
+      "\n",
+      "\u001b[1m\u001b[36martifacts\u001b[m\u001b[m     \u001b[1m\u001b[36mfeatures\u001b[m\u001b[m      \u001b[1m\u001b[36mmetrics\u001b[m\u001b[m\n",
+      "\u001b[1m\u001b[36mdataframes\u001b[m\u001b[m    metadata.json \u001b[1m\u001b[36mparameters\u001b[m\u001b[m\n",
+      "\n",
+      "\n",
+      "\u001b[1m\u001b[36maf003e41-6278-412c-8511-ccfbc2813cf3\u001b[m\u001b[m\n",
+      "\n",
+      "\n",
+      "\u001b[1m\u001b[36mc241e0c6-ce22-49fd-9555-7e73ba16e63d\u001b[m\u001b[m\n",
+      "\n",
+      "\n",
+      "\u001b[1m\u001b[36myear\u001b[m\u001b[m\n",
+      "\n",
+      "\n",
+      "\u001b[1m\u001b[36maccuracy\u001b[m\u001b[m\n",
+      "\n",
+      "\n",
+      "\u001b[1m\u001b[36mnestimators\u001b[m\u001b[m\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ls \"./local/rootB\"\n",
+    "print(\"\\n\")\n",
+    "!ls \"./local/rootB/exampleproject\"\n",
+    "print(\"\\n\")\n",
+    "!ls \"./local/rootB/exampleproject/experiments\"\n",
+    "print(\"\\n\")\n",
+    "!ls \"./local/rootB/exampleproject/experiments/{experiment.id}\" \n",
+    "print(\"\\n\")\n",
+    "!ls \"./local/rootB/exampleproject/experiments/{experiment.id}/artifacts\"\n",
+    "print(\"\\n\")\n",
+    "!ls \"./local/rootB/exampleproject/experiments/{experiment.id}/dataframes\"\n",
+    "print(\"\\n\")\n",
+    "!ls \"./local/rootB/exampleproject/experiments/{experiment.id}/features\"\n",
+    "print(\"\\n\")\n",
+    "!ls \"./local/rootB/exampleproject/experiments/{experiment.id}/metrics\"\n",
+    "print(\"\\n\")\n",
+    "!ls \"./local/rootB/exampleproject/experiments/{experiment.id}/parameters\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12a5c1df",
+   "metadata": {},
+   "source": [
+    "### Read Commands\n",
+    "Now that we've seen both of our backends have been written to, let's see the read commands. Read commands will iterate over all backend repositories and return from the first one they are able to read from. A `RubiconException` will be raised if none of the backend repositories can be read the requested item(s)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "0a2eda44",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "projects: [<rubicon_ml.client.project.Project object at 0x13322d810>]\n",
+      "\n",
+      "\n",
+      "experiments: [<rubicon_ml.client.experiment.Experiment object at 0x13322f100>]\n",
+      "\n",
+      "\n",
+      "artifacts: [<rubicon_ml.client.artifact.Artifact object at 0x13322f730>]\n",
+      "\n",
+      "\n",
+      "dataframes: [<rubicon_ml.client.dataframe.Dataframe object at 0x13322f6a0>]\n",
+      "\n",
+      "\n",
+      "features: [<rubicon_ml.client.feature.Feature object at 0x1331ee200>]\n",
+      "\n",
+      "\n",
+      "metrics: [<rubicon_ml.client.metric.Metric object at 0x13322d120>]\n",
+      "\n",
+      "\n",
+      "parameters: [<rubicon_ml.client.parameter.Parameter object at 0x13327c1c0>]\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "projects = rb.projects()\n",
+    "print(\"projects: \" + str(projects))\n",
+    "print(\"\\n\")\n",
+    "\n",
+    "experiments = project.experiments()\n",
+    "print(\"experiments: \" + str(experiments))\n",
+    "print(\"\\n\")\n",
+    "\n",
+    "artifacts = experiment.artifacts()\n",
+    "print(\"artifacts: \" + str(artifacts))\n",
+    "print(\"\\n\")\n",
+    "\n",
+    "dataframes = experiment.dataframes()\n",
+    "print(\"dataframes: \" + str(dataframes))\n",
+    "print(\"\\n\")\n",
+    "\n",
+    "features = experiment.features()\n",
+    "print(\"features: \" + str(features))\n",
+    "print(\"\\n\")\n",
+    "\n",
+    "metrics = experiment.metrics()\n",
+    "print(\"metrics: \" + str(metrics))\n",
+    "print(\"\\n\")\n",
+    "\n",
+    "parameters = experiment.parameters()\n",
+    "print(\"parameters: \" + str(parameters))\n",
+    "print(\"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "faf2bfcd",
+   "metadata": {},
+   "source": [
+    "#### Additional Read Commands\n",
+    "Along with the commands demonstrated above, all other \"read\" type rubicon commands work the same way in that they will iterate over backend repositories and return from the first one they are able to read from. These include commands which read a specific logged object like `get_project()`, `experiment()`, `artifact()`, `dataframe()`, `metric()`, and `parameter()`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## What 
  * Branched off of main after merging `multiple-backend` and closed previous PR
  * Adds example notebook for `multiple-backend` feature
  * Adds notebook to docs

## How to Test
  * run notebook
  * run the following commands to build docs
```
conda activate rubicon-ml-docs
cd docs
make html
open ./build/html/index.html
```
