### PR TITLE
Add tests for ValueError

### DIFF
--- a/tests/unit/client/test_experiment_client.py
+++ b/tests/unit/client/test_experiment_client.py
@@ -1,3 +1,5 @@
+import pytest
+
 from rubicon_ml import domain
 from rubicon_ml.client import Experiment
 
@@ -72,6 +74,28 @@ def test_get_metric_by_name(project_client):
 
     metric = experiment.metric(name="accuracy").name
     assert metric == "accuracy"
+
+
+def test_get_metric_fails_neither_set(project_client):
+    project = project_client
+    experiment = project.log_experiment(name="exp1")
+    experiment.log_metric("accuracy", 100)
+
+    with pytest.raises(ValueError) as e:
+        experiment.metric(name=None, id=None)
+
+    assert "`name` OR `id` required." in str(e)
+
+
+def test_get_metric_fails_both_set(project_client):
+    project = project_client
+    experiment = project.log_experiment(name="exp1")
+    experiment.log_metric("accuracy", 100)
+
+    with pytest.raises(ValueError) as e:
+        experiment.metric(name="foo", id=123)
+
+    assert "`name` OR `id` required." in str(e)
 
 
 def test_metrics_tagged_and(project_client):
@@ -154,6 +178,28 @@ def test_get_feature_by_id(project_client):
     assert feature == "year"
 
 
+def test_get_feature_fails_neither_set(project_client):
+    project = project_client
+    experiment = project.log_experiment(name="exp1")
+    experiment.log_feature("year")
+
+    with pytest.raises(ValueError) as e:
+        experiment.feature(name=None, id=None)
+
+    assert "`name` OR `id` required." in str(e)
+
+
+def test_get_feature_fails_both_set(project_client):
+    project = project_client
+    experiment = project.log_experiment(name="exp1")
+    experiment.log_feature("year")
+
+    with pytest.raises(ValueError) as e:
+        experiment.feature(name="foo", id=123)
+
+    assert "`name` OR `id` required." in str(e)
+
+
 def test_features_tagged_and(project_client):
     project = project_client
     experiment = project.log_experiment(name="exp1")
@@ -224,6 +270,28 @@ def test_get_parameter_by_id(project_client):
 
     parameter = experiment.parameter(id=parameter_id).name
     assert parameter == "n_estimators"
+
+
+def test_get_parameter_fails_neither_set(project_client):
+    project = project_client
+    experiment = project.log_experiment(name="exp1")
+    experiment.log_parameter("n_estimators", "estimator")
+
+    with pytest.raises(ValueError) as e:
+        experiment.parameter(name=None, id=None)
+
+    assert "`name` OR `id` required." in str(e)
+
+
+def test_get_parameter_fails_both_set(project_client):
+    project = project_client
+    experiment = project.log_experiment(name="exp1")
+    experiment.log_parameter("n_estimators", "estimator")
+
+    with pytest.raises(ValueError) as e:
+        experiment.parameter(name="foo", id=123)
+
+    assert "`name` OR `id` required." in str(e)
 
 
 def test_parameters_tagged_and(project_client):

--- a/tests/unit/client/test_mixin_client.py
+++ b/tests/unit/client/test_mixin_client.py
@@ -332,6 +332,23 @@ def test_dataframes_by_name_not_found(project_client, test_dataframe):
     assert dataframes == []
 
 
+def test_get_dataframe_fails_both_set(project_client, test_dataframe):
+    project = project_client
+    with pytest.raises(ValueError) as e:
+        DataframeMixin.dataframe(project, name="foo", id=123)
+
+    assert "`name` OR `id` required." in str(e.value)
+
+
+def test_get_dataframe_fails_neither_set(project_client, test_dataframe):
+    project = project_client
+
+    with pytest.raises(ValueError) as e:
+        DataframeMixin.dataframe(project, name=None, id=None)
+
+    assert "`name` OR `id` required." in str(e.value)
+
+
 def test_dataframes_tagged_and(project_client, test_dataframe):
     project = project_client
     df = test_dataframe

--- a/tests/unit/client/test_project_client.py
+++ b/tests/unit/client/test_project_client.py
@@ -121,6 +121,24 @@ def test_experiment_by_name(project_client):
     assert experiment.name == "exp1"
 
 
+def test_get_experiment_fails_both_set(project_client):
+    project = project_client
+    project.log_experiment(name="exp1")
+    with pytest.raises(ValueError) as e:
+        project.experiment(name="foo", id=123)
+
+    assert "`name` OR `id` required." in str(e.value)
+
+
+def test_get_experiment_fails_neither_set(project_client):
+    project = project_client
+    project.log_experiment(name="exp1")
+    with pytest.raises(ValueError) as e:
+        project.experiment(name=None, id=None)
+
+    assert "`name` OR `id` required." in str(e.value)
+
+
 def test_experiment_warning(project_client, test_dataframe):
     project = project_client
     experiment_a = project.log_experiment(name="exp1")

--- a/tests/unit/client/test_rubicon_client.py
+++ b/tests/unit/client/test_rubicon_client.py
@@ -107,6 +107,22 @@ def test_get_project_by_id(rubicon_and_project_client):
     assert project_id == rubicon.get_project(id=project_id).id
 
 
+def test_get_project_fails_both_set(rubicon_and_project_client):
+    rubicon, project = rubicon_and_project_client
+    with pytest.raises(ValueError) as e:
+        rubicon.get_project(name="foo", id=123)
+
+    assert "`name` OR `id` required." in str(e.value)
+
+
+def test_get_project_fails_neither_set(rubicon_and_project_client):
+    rubicon, project = rubicon_and_project_client
+    with pytest.raises(ValueError) as e:
+        rubicon.get_project(name=None, id=None)
+
+    assert "`name` OR `id` required." in str(e.value)
+
+
 def test_get_projects(rubicon_client):
     rubicon = rubicon_client
     rubicon.create_project("Project A")


### PR DESCRIPTION
closes: #142 

---


## What
  *  Adds unit tests to verify that passing either both `name` and `id` as `None` or both as not `None` results in a ValueError.

## How to Test
  * This PR adds tests only which will be triggered during the CI/CD process.

