### PR TITLE
S3 archiving fix - post rebase

### DIFF
--- a/rubicon_ml/intake_rubicon/publish.py
+++ b/rubicon_ml/intake_rubicon/publish.py
@@ -49,7 +49,6 @@ def publish(
 
 
 def _update_catalog(base_catalog_filepath, new_experiments, output_filepath=None):
-
     """Helper function to update exisiting intake catalog.
 
     Parameters
@@ -92,7 +91,6 @@ def _update_catalog(base_catalog_filepath, new_experiments, output_filepath=None
 
 
 def _build_catalog(experiments):
-
     """Helper function to build catalog dictionary from given experiments.
 
     Parameters

--- a/tests/unit/client/test_project_client.py
+++ b/tests/unit/client/test_project_client.py
@@ -2,6 +2,7 @@ import os
 import time
 import warnings
 from unittest import mock
+from unittest.mock import patch
 
 import pytest
 
@@ -489,3 +490,24 @@ def test_experiments_from_archive_latest_only():
     assert new_num_expsB == 4
     rubiconA.repository.filesystem.rm(rubiconA.config.root_dir, recursive=True)
     rubiconB.repository.filesystem.rm(rubiconB.config.root_dir, recursive=True)
+
+
+@patch("fsspec.open")
+def test_archive_remote_rubicon_s3(mock_open):
+    print("buffer")
+    rubicon_a = Rubicon(
+        persistence="filesystem",
+        root_dir=os.path.join(os.path.dirname(os.path.realpath(__file__)), "rubiconA"),
+    )
+    s3_repo = "s3://bucket/root/path/to/data"
+
+    rubicon_b = Rubicon(persistence="filesystem", root_dir=s3_repo)
+
+    projectA = rubicon_a.get_or_create_project("ArchiveTesting")
+    projectA.log_experiment(name="experiment1")
+    projectA.log_experiment(name="experiment2")
+
+    zip_archive_filename = projectA.archive(remote_rubicon=rubicon_b)
+
+    mock_open.assert_called_once_with(zip_archive_filename, "wb")
+    rubicon_a.repository.filesystem.rm(rubicon_a.config.root_dir, recursive=True)


### PR DESCRIPTION
closes: #360

---

## What
  * Fixes bug in archiving to remote rubicon S3. 
  * Added unit test 

## How to Test
  * run unit tests
  * For a more thorough test, utilize a Kubeflow notebook that has an IAM role attached and run archiving functionality against any given S3 bucket attached to the role 

