### PR TITLE
json query bugfix

### DIFF
--- a/rubicon_ml/client/rubicon_json.py
+++ b/rubicon_ml/client/rubicon_json.py
@@ -97,30 +97,26 @@ class RubiconJSON:
         rubicon_json: Dict[str, Any] = {"experiment": []}
 
         for e in experiments:
-            experiment_json = update_domain(e._domain.__dict__)
-            experiment_json["feature"] = [update_domain(f._domain.__dict__) for f in e.features()]
+            experiment_json = copy.deepcopy(e._domain.__dict__)
+            experiment_json["feature"] = [f._domain.__dict__ for f in e.features()]
             experiment_json["parameter"] = [
                 update_domain(p._domain.__dict__) for p in e.parameters()
             ]
             experiment_json["metric"] = [update_domain(m._domain.__dict__) for m in e.metrics()]
-            experiment_json["artifact"] = [update_domain(a._domain.__dict__) for a in e.artifacts()]
-            experiment_json["dataframe"] = [
-                update_domain(d._domain.__dict__) for d in e.dataframes()
-            ]
+            experiment_json["artifact"] = [a._domain.__dict__ for a in e.artifacts()]
+            experiment_json["dataframe"] = [d._domain.__dict__ for d in e.dataframes()]
 
             rubicon_json["experiment"].append(experiment_json)
 
         return rubicon_json
 
     def _projects_to_json(self, projects: List[Project], numericize: bool = False):
-        update_domain = _numericize_domain if numericize else lambda domain: domain
-
         rubicon_json: Dict[str, Any] = {"project": []}
 
         for p in projects:
-            project_json = update_domain(p._domain.__dict__)
-            project_json["artifact"] = [update_domain(a._domain.__dict__) for a in p.artifacts()]
-            project_json["dataframe"] = [update_domain(d._domain.__dict__) for d in p.dataframes()]
+            project_json = p._domain.__dict__
+            project_json["artifact"] = [a._domain.__dict__ for a in p.artifacts()]
+            project_json["dataframe"] = [d._domain.__dict__ for d in p.dataframes()]
 
             experiment_json = self._experiments_to_json(p.experiments(), numericize=numericize)
             project_json["experiment"] = experiment_json["experiment"]

--- a/tests/unit/client/test_rubicon_json_client.py
+++ b/tests/unit/client/test_rubicon_json_client.py
@@ -11,6 +11,7 @@ def test_experiment_to_json_single_experiment(rubicon_and_project_client):
     experiment.log_feature("year")
     experiment.log_metric("accuracy", 0.87)
     experiment.log_metric("runtime(s)", 45)
+    experiment.log_metric("kernel", "linear")
     experiment.log_artifact(name="example artifact", data_bytes=b"a")
     experiment.log_dataframe(pd.DataFrame([[0, 1], [1, 0]]))
 
@@ -30,8 +31,18 @@ def test_experiment_to_json_single_experiment(rubicon_and_project_client):
     assert isinstance(json["experiment"][0]["artifact"], list)
     assert isinstance(json["experiment"][0]["dataframe"], list)
 
+    assert isinstance(json["experiment"][0]["metric"][0]["value"], float)
+    assert isinstance(json["experiment"][0]["metric"][1]["value"], int)
+    assert isinstance(json["experiment"][0]["metric"][2]["value"], str)
+
     assert json["experiment"][0]["tags"] == ["a", "b"]
-    assert len(json["experiment"][0]["metric"]) == 2
+    assert len(json["experiment"][0]["metric"]) == 3
+
+    json_numeric = experiment_as_json.json_numeric
+
+    assert isinstance(json_numeric["experiment"][0]["metric"][0]["value"], float)
+    assert isinstance(json_numeric["experiment"][0]["metric"][1]["value"], int)
+    assert isinstance(json_numeric["experiment"][0]["metric"][2]["value"], int)
 
 
 def test_experiment_to_json_multiple_experiments(rubicon_and_project_client_with_experiments):
@@ -158,3 +169,24 @@ def test_convert_to_json_projects_and_experiments_input(
     assert isinstance(json, dict)
     assert isinstance(json["project"], list)
     assert len(json["experiment"]) == 2
+
+
+@pytest.mark.parametrize(
+    ["query", "expected_results"],
+    [
+        ("$..experiment[*].metric[?(@.value>0.0)].name", ["accuracy", "runtime(s)"]),
+        ("$..experiment[*].metric[?(@.name='kernel')].value", ["linear"]),
+    ],
+)
+def test_search(query, expected_results, rubicon_and_project_client):
+    _, project = rubicon_and_project_client
+    experiment = project.log_experiment("search experiment", tags=["a", "b"])
+    experiment.log_metric("accuracy", 0.87)
+    experiment.log_metric("runtime(s)", 45)
+    experiment.log_metric("kernel", "linear")
+
+    experiment_as_json = RubiconJSON(experiments=experiment)
+    results = experiment_as_json.search(query)
+
+    for result, expected_result in zip(results, expected_results):
+        assert result.value == expected_result

--- a/tests/unit/client/test_rubicon_json_client.py
+++ b/tests/unit/client/test_rubicon_json_client.py
@@ -42,7 +42,8 @@ def test_experiment_to_json_single_experiment(rubicon_and_project_client):
 
     assert isinstance(json_numeric["experiment"][0]["metric"][0]["value"], float)
     assert isinstance(json_numeric["experiment"][0]["metric"][1]["value"], int)
-    assert isinstance(json_numeric["experiment"][0]["metric"][2]["value"], int)
+
+    assert len(json_numeric["experiment"][0]["metric"]) == 2
 
 
 def test_experiment_to_json_multiple_experiments(rubicon_and_project_client_with_experiments):


### PR DESCRIPTION
## What
  * deals with a bug in `jsonpath-ng` where non-homogenous values cause issues when querying with comparison operators (<, <=, >, >=)
    * e.g. all metrics have a value - if some have int values and some have str values, even queries over just the int ones will process the str ones as well and error as you can not compare an int and a str with <, >, etc.
  * adds an additional `json_numeric` that removes all entities with a non-numeric "value"
  * query `json_numeric` instead of `json` when < or > is in the query

## How to Test
  * `python -m pytest tests/unit/client/test_rubicon_json_client.py`
