### PR TITLE
tag experiment parent/child relationships

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -137,6 +137,7 @@ To install all extra modules, use the ``all`` extra.
    integrations/integration-sklearn
    logging-examples/logging-feature-plots
    logging-examples/multiple-backend
+   logging-examples/manage-experiment-relationships
    logging-examples/register-custom-schema
    logging-examples/set-schema
    logging-examples/visualizing-logged-dataframes

--- a/notebooks/logging-examples/manage-experiment-relationships.ipynb
+++ b/notebooks/logging-examples/manage-experiment-relationships.ipynb
@@ -1,0 +1,233 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "815af48c-67f4-4335-bf16-11068f7094bb",
+   "metadata": {},
+   "source": [
+    "# Manage Experiment Relationships\n",
+    "\n",
+    "``rubicon-ml`` experiments can be tagged with special identifiers to denote a parent/child relationship.\n",
+    "This can be used to track hierarchical or iterative experiments, among other things.\n",
+    "\n",
+    "First, let's create a project."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c44f140a-0d40-4919-b058-8f986dd9bcb1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<rubicon_ml.client.project.Project at 0x11a983b10>"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from rubicon_ml import Rubicon\n",
+    "\n",
+    "rubicon = Rubicon(persistence=\"memory\")\n",
+    "project = rubicon.create_project(name=\"hierarchical experiments\")\n",
+    "project"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9aee6c2-8891-4a5b-98d6-37cce80bb40f",
+   "metadata": {},
+   "source": [
+    "## Hierarchical experiments\n",
+    "\n",
+    "Now we can log some experiments in a nested loop. Imagine logging an experiment for each node of a\n",
+    "gradient boosted tree, or something along those lines.\n",
+    "\n",
+    "We can use ``parent_experiment.add_child_experiment(child_experiment)`` to automatically add tags\n",
+    "to both ``parent_experiment`` and ``child_experiment`` that represent their relationship."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "af1bd79b-dd77-4ccb-affb-8abea69f581b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "root_experiment = project.log_experiment(name=\"root\")\n",
+    "\n",
+    "for n in range(3):\n",
+    "    node_experiment = project.log_experiment(name=f\"node_{n}\")\n",
+    "    root_experiment.add_child_experiment(node_experiment)\n",
+    "\n",
+    "    for m in range(2):\n",
+    "        nested_node_experiment = project.log_experiment(name=f\"node_{n}_{m}\")\n",
+    "        node_experiment.add_child_experiment(nested_node_experiment)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2f6583c-081a-4afe-ba3a-5e6b8744f274",
+   "metadata": {},
+   "source": [
+    "To retrieve experiments, start at the root experiment and call ``get_child_experiments`` to return a\n",
+    "list of ``rubicon-ml`` objects representing each of the tagged child experiments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "30068979-44ad-4fd5-9dab-6a2dbee66078",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "id: 12fac8d7-ce2a-4229-a545-286aa2539609\n",
+      "tags: ['child:c2db7703-d7a8-4e50-bd88-445ca1cb1410', 'child:fff24ae1-fa82-4526-bac9-d8d27e58f1f7'] \n",
+      "\n",
+      "\tid: c2db7703-d7a8-4e50-bd88-445ca1cb1410\n",
+      "\ttags: ['parent:12fac8d7-ce2a-4229-a545-286aa2539609'] \n",
+      "\n",
+      "\tid: fff24ae1-fa82-4526-bac9-d8d27e58f1f7\n",
+      "\ttags: ['parent:12fac8d7-ce2a-4229-a545-286aa2539609'] \n",
+      "\n",
+      "id: 74c3c5f2-b201-4460-a250-d42c29fa799f\n",
+      "tags: ['child:f1531c94-e626-4600-b018-cbb41d29e861', 'child:c729eb4c-7131-4339-8e91-ac6e786aafe6'] \n",
+      "\n",
+      "\tid: f1531c94-e626-4600-b018-cbb41d29e861\n",
+      "\ttags: ['parent:74c3c5f2-b201-4460-a250-d42c29fa799f'] \n",
+      "\n",
+      "\tid: c729eb4c-7131-4339-8e91-ac6e786aafe6\n",
+      "\ttags: ['parent:74c3c5f2-b201-4460-a250-d42c29fa799f'] \n",
+      "\n",
+      "id: 7ab02de9-a07b-4394-983a-e1cb17f16cb4\n",
+      "tags: ['child:d54e32d8-c1ac-4182-9a74-d07da0b5980a', 'child:3b47be81-7a1e-49be-ad9c-d48070fa06ba'] \n",
+      "\n",
+      "\tid: d54e32d8-c1ac-4182-9a74-d07da0b5980a\n",
+      "\ttags: ['parent:7ab02de9-a07b-4394-983a-e1cb17f16cb4'] \n",
+      "\n",
+      "\tid: 3b47be81-7a1e-49be-ad9c-d48070fa06ba\n",
+      "\ttags: ['parent:7ab02de9-a07b-4394-983a-e1cb17f16cb4'] \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "for experiment in root_experiment.get_child_experiments():\n",
+    "    print(\"id:\", experiment.id)\n",
+    "    print(\"tags:\", [t for t in experiment.tags if \"child\" in t], \"\\n\")\n",
+    "\n",
+    "    for nested_experiment in experiment.get_child_experiments():\n",
+    "        print(\"\\tid:\", nested_experiment.id)\n",
+    "        print(\"\\ttags:\", nested_experiment.tags, \"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12bc18eb-0edd-4054-840b-c4b969a150fb",
+   "metadata": {},
+   "source": [
+    "## Iterative experiments\n",
+    "\n",
+    "We can leverage ``add_child_experiment`` to maintain iterative relationships too. This could be\n",
+    "used to log metadata about of each iteration of recursive feature elimination and preserve the\n",
+    "linear history of the model training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0f104792-7cbf-4508-b37c-11dfb158b608",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "current_experiment = project.log_experiment(name=\"experiment_0\")\n",
+    "\n",
+    "for n in range(3):\n",
+    "    next_experiment = project.log_experiment(name=f\"experiment_{n+1}\")\n",
+    "    current_experiment.add_child_experiment(next_experiment)\n",
+    "\n",
+    "    current_experiment = next_experiment\n",
+    "\n",
+    "last_experiment = current_experiment"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0f42e74-8fc2-460a-9282-ed0492639d75",
+   "metadata": {},
+   "source": [
+    "Similarly to ``get_child_experiments``, we can use ``get_parent_experiment`` to return a ``rubicon-ml``\n",
+    "object representing the tagged parent experiment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "35613e52-84f1-4d2e-8e3c-8c0f2b731d89",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "name: experiment_3\n",
+      "\tid: 1d8d3f84-44bc-423b-9d41-27193e948732\n",
+      "\ttags: ['parent:2ace6121-91b8-435b-a786-9b8bc8615430'] \n",
+      "\n",
+      "name: experiment_2\n",
+      "\tid: 2ace6121-91b8-435b-a786-9b8bc8615430\n",
+      "\ttags: ['parent:60bda2d6-5f7d-4c10-a2be-a09d00ce7a9c', 'child:1d8d3f84-44bc-423b-9d41-27193e948732'] \n",
+      "\n",
+      "name: experiment_1\n",
+      "\tid: 60bda2d6-5f7d-4c10-a2be-a09d00ce7a9c\n",
+      "\ttags: ['child:2ace6121-91b8-435b-a786-9b8bc8615430', 'parent:785a1d46-eddd-44a5-8be8-4d07662f2af2'] \n",
+      "\n",
+      "name: experiment_0\n",
+      "\tid: 785a1d46-eddd-44a5-8be8-4d07662f2af2\n",
+      "\ttags: ['child:60bda2d6-5f7d-4c10-a2be-a09d00ce7a9c'] \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "experiment = last_experiment\n",
+    "\n",
+    "while experiment is not None:\n",
+    "    print(\"name:\", experiment.name)\n",
+    "    print(\"\\tid:\", experiment.id)\n",
+    "    print(\"\\ttags:\", experiment.tags, \"\\n\")\n",
+    "\n",
+    "    experiment = experiment.get_parent_experiment()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/logging-examples/manage-experiment-relationships.ipynb
+++ b/notebooks/logging-examples/manage-experiment-relationships.ipynb
@@ -22,7 +22,7 @@
     {
      "data": {
       "text/plain": [
-       "<rubicon_ml.client.project.Project at 0x11a983b10>"
+       "<rubicon_ml.client.project.Project at 0x121d7af50>"
       ]
      },
      "execution_count": 1,
@@ -89,32 +89,32 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "id: 12fac8d7-ce2a-4229-a545-286aa2539609\n",
-      "tags: ['child:c2db7703-d7a8-4e50-bd88-445ca1cb1410', 'child:fff24ae1-fa82-4526-bac9-d8d27e58f1f7'] \n",
+      "id: f8c897d7-852d-4020-8715-264452a5b8ab\n",
+      "tags: ['child:754dff35-aa87-4385-9bcd-af5c1f5b0b7e', 'child:fdf25d72-d1bb-47bc-8cb2-4a088ed0ba33'] \n",
       "\n",
-      "\tid: c2db7703-d7a8-4e50-bd88-445ca1cb1410\n",
-      "\ttags: ['parent:12fac8d7-ce2a-4229-a545-286aa2539609'] \n",
+      "\tid: 754dff35-aa87-4385-9bcd-af5c1f5b0b7e\n",
+      "\ttags: ['parent:f8c897d7-852d-4020-8715-264452a5b8ab'] \n",
       "\n",
-      "\tid: fff24ae1-fa82-4526-bac9-d8d27e58f1f7\n",
-      "\ttags: ['parent:12fac8d7-ce2a-4229-a545-286aa2539609'] \n",
+      "\tid: fdf25d72-d1bb-47bc-8cb2-4a088ed0ba33\n",
+      "\ttags: ['parent:f8c897d7-852d-4020-8715-264452a5b8ab'] \n",
       "\n",
-      "id: 74c3c5f2-b201-4460-a250-d42c29fa799f\n",
-      "tags: ['child:f1531c94-e626-4600-b018-cbb41d29e861', 'child:c729eb4c-7131-4339-8e91-ac6e786aafe6'] \n",
+      "id: 5f8c14c1-50d9-4c49-b0b2-6a59c6f3d707\n",
+      "tags: ['child:d9012c99-2888-43d1-833b-78d51de75a3a', 'child:c65f8c5e-bf5b-4a82-94cb-8b669545b951'] \n",
       "\n",
-      "\tid: f1531c94-e626-4600-b018-cbb41d29e861\n",
-      "\ttags: ['parent:74c3c5f2-b201-4460-a250-d42c29fa799f'] \n",
+      "\tid: d9012c99-2888-43d1-833b-78d51de75a3a\n",
+      "\ttags: ['parent:5f8c14c1-50d9-4c49-b0b2-6a59c6f3d707'] \n",
       "\n",
-      "\tid: c729eb4c-7131-4339-8e91-ac6e786aafe6\n",
-      "\ttags: ['parent:74c3c5f2-b201-4460-a250-d42c29fa799f'] \n",
+      "\tid: c65f8c5e-bf5b-4a82-94cb-8b669545b951\n",
+      "\ttags: ['parent:5f8c14c1-50d9-4c49-b0b2-6a59c6f3d707'] \n",
       "\n",
-      "id: 7ab02de9-a07b-4394-983a-e1cb17f16cb4\n",
-      "tags: ['child:d54e32d8-c1ac-4182-9a74-d07da0b5980a', 'child:3b47be81-7a1e-49be-ad9c-d48070fa06ba'] \n",
+      "id: da33e918-96c0-4e56-9075-7941515cc18f\n",
+      "tags: ['child:7c5b2f4b-1e7c-40be-8cda-8f3a00067e98', 'child:cd30f3b2-bd63-4318-974a-6668648bf4ac'] \n",
       "\n",
-      "\tid: d54e32d8-c1ac-4182-9a74-d07da0b5980a\n",
-      "\ttags: ['parent:7ab02de9-a07b-4394-983a-e1cb17f16cb4'] \n",
+      "\tid: 7c5b2f4b-1e7c-40be-8cda-8f3a00067e98\n",
+      "\ttags: ['parent:da33e918-96c0-4e56-9075-7941515cc18f'] \n",
       "\n",
-      "\tid: 3b47be81-7a1e-49be-ad9c-d48070fa06ba\n",
-      "\ttags: ['parent:7ab02de9-a07b-4394-983a-e1cb17f16cb4'] \n",
+      "\tid: cd30f3b2-bd63-4318-974a-6668648bf4ac\n",
+      "\ttags: ['parent:da33e918-96c0-4e56-9075-7941515cc18f'] \n",
       "\n"
      ]
     }
@@ -179,33 +179,35 @@
      "output_type": "stream",
      "text": [
       "name: experiment_3\n",
-      "\tid: 1d8d3f84-44bc-423b-9d41-27193e948732\n",
-      "\ttags: ['parent:2ace6121-91b8-435b-a786-9b8bc8615430'] \n",
+      "\tid: a85ba9d9-1473-44c2-b3e9-8a744534485b\n",
+      "\ttags: ['parent:47ecf8a7-b799-4308-994b-aa6d8698dc2b'] \n",
       "\n",
       "name: experiment_2\n",
-      "\tid: 2ace6121-91b8-435b-a786-9b8bc8615430\n",
-      "\ttags: ['parent:60bda2d6-5f7d-4c10-a2be-a09d00ce7a9c', 'child:1d8d3f84-44bc-423b-9d41-27193e948732'] \n",
+      "\tid: 47ecf8a7-b799-4308-994b-aa6d8698dc2b\n",
+      "\ttags: ['child:a85ba9d9-1473-44c2-b3e9-8a744534485b', 'parent:aea5f005-9792-442c-b98c-8d9b9e39f99b'] \n",
       "\n",
       "name: experiment_1\n",
-      "\tid: 60bda2d6-5f7d-4c10-a2be-a09d00ce7a9c\n",
-      "\ttags: ['child:2ace6121-91b8-435b-a786-9b8bc8615430', 'parent:785a1d46-eddd-44a5-8be8-4d07662f2af2'] \n",
+      "\tid: aea5f005-9792-442c-b98c-8d9b9e39f99b\n",
+      "\ttags: ['child:47ecf8a7-b799-4308-994b-aa6d8698dc2b', 'parent:f4a393ef-0b32-4f70-ac82-07a0877da328'] \n",
       "\n",
       "name: experiment_0\n",
-      "\tid: 785a1d46-eddd-44a5-8be8-4d07662f2af2\n",
-      "\ttags: ['child:60bda2d6-5f7d-4c10-a2be-a09d00ce7a9c'] \n",
+      "\tid: f4a393ef-0b32-4f70-ac82-07a0877da328\n",
+      "\ttags: ['child:aea5f005-9792-442c-b98c-8d9b9e39f99b'] \n",
       "\n"
      ]
     }
    ],
    "source": [
-    "experiment = last_experiment\n",
+    "experiments = [last_experiment]\n",
     "\n",
-    "while experiment is not None:\n",
+    "while len(experiments) != 0:\n",
+    "    experiment = experiments[0]\n",
+    "\n",
     "    print(\"name:\", experiment.name)\n",
     "    print(\"\\tid:\", experiment.id)\n",
     "    print(\"\\ttags:\", experiment.tags, \"\\n\")\n",
     "\n",
-    "    experiment = experiment.get_parent_experiment()"
+    "    experiments = experiment.get_parent_experiments()"
    ]
   }
  ],

--- a/rubicon_ml/client/experiment.py
+++ b/rubicon_ml/client/experiment.py
@@ -362,6 +362,18 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
             return [p for p in self.parameters() if p.id == id][0]
 
     def add_child_experiment(self, experiment: Experiment):
+        """Add tags to denote `experiment` as a descendent of this experiment.
+
+        Parameters
+        ----------
+        experiment : rubicon_ml.client.Experiment
+            The experiment to mark as a descendent of this experiment.
+
+        Raises
+        ------
+        RubiconException
+            If `experiment` and this experiment are not logged to the same project.
+        """
         if experiment.project.id != self.project.id:
             raise RubiconException(
                 "Descendents must be logged to the same project. Project"
@@ -375,6 +387,13 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
         experiment.add_tags([parent_tag])
 
     def get_child_experiments(self):
+        """Get the experiments that are tagged as children of this experiment.
+
+        Returns
+        -------
+        list of rubicon_ml.client.Experiment
+            The experiments that are tagged as children of this experiment.
+        """
         children = []
 
         for tag in self.tags:
@@ -385,6 +404,13 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
         return children
 
     def get_parent_experiment(self):
+        """Get the experiments that are tagged as parents of this experiment.
+
+        Returns
+        -------
+        list of rubicon_ml.client.Experiment
+            The experiments that are tagged as parents of this experiment.
+        """
         parent = None
 
         for tag in self.tags:

--- a/rubicon_ml/client/experiment.py
+++ b/rubicon_ml/client/experiment.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from rubicon_ml import domain
 from rubicon_ml.client import (
@@ -404,7 +404,7 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
 
         return experiments
 
-    def get_child_experiments(self):
+    def get_child_experiments(self) -> List[Experiment]:
         """Get the experiments that are tagged as children of this experiment.
 
         Returns
@@ -414,7 +414,7 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
         """
         return self._get_experiments_from_tags("child")
 
-    def get_parent_experiments(self):
+    def get_parent_experiments(self) -> List[Experiment]:
         """Get the experiments that are tagged as parents of this experiment.
 
         Returns

--- a/rubicon_ml/client/experiment.py
+++ b/rubicon_ml/client/experiment.py
@@ -386,6 +386,24 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
         self.add_tags([child_tag])
         experiment.add_tags([parent_tag])
 
+    def _get_experiments_from_tags(self, tag_key: str):
+        """Get the experiments with `experiment_id`s in this experiment's tags
+        that match the format `tag_key:experiment_id`.
+
+        Returns
+        -------
+        list of rubicon_ml.client.Experiment
+            The experiments with `experiment_id`s in this experiment's tags.
+        """
+        experiments = []
+
+        for tag in self.tags:
+            if f"{tag_key}:" in tag:
+                experiment_id = tag.split(":")[-1]
+                experiments.append(self.project.experiment(id=experiment_id))
+
+        return experiments
+
     def get_child_experiments(self):
         """Get the experiments that are tagged as children of this experiment.
 
@@ -394,16 +412,9 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
         list of rubicon_ml.client.Experiment
             The experiments that are tagged as children of this experiment.
         """
-        children = []
+        return self._get_experiments_from_tags("child")
 
-        for tag in self.tags:
-            if "child:" in tag:
-                child_id = tag.split(":")[-1]
-                children.append(self.project.experiment(id=child_id))
-
-        return children
-
-    def get_parent_experiment(self):
+    def get_parent_experiments(self):
         """Get the experiments that are tagged as parents of this experiment.
 
         Returns
@@ -411,14 +422,7 @@ class Experiment(Base, ArtifactMixin, DataframeMixin, TagMixin):
         list of rubicon_ml.client.Experiment
             The experiments that are tagged as parents of this experiment.
         """
-        parent = None
-
-        for tag in self.tags:
-            if "parent:" in tag:
-                parent_id = tag.split(":")[-1]
-                parent = self.project.experiment(id=parent_id)
-
-        return parent
+        return self._get_experiments_from_tags("parent")
 
     @property
     def id(self):

--- a/tests/unit/client/test_experiment_client.py
+++ b/tests/unit/client/test_experiment_client.py
@@ -394,3 +394,34 @@ def test_parameters_tagged_or(project_client):
     assert len(parameters) == 2
     assert param_a.id in [d.id for d in parameters]
     assert param_b.id in [d.id for d in parameters]
+
+
+def test_add_child_experiment(project_client):
+    project = project_client
+    parent = project.log_experiment(name="parent")
+    child = project.log_experiment(name="child")
+
+    parent.add_child_experiment(child)
+
+    assert f"parent:{parent.id}" in child.tags
+    assert f"child:{child.id}" in parent.tags
+
+
+def test_get_child_experiments(project_client):
+    project = project_client
+    parent = project.log_experiment(name="parent")
+    child = project.log_experiment(name="child")
+
+    parent.add_child_experiment(child)
+
+    assert parent.get_child_experiments()[0].id == child.id
+
+
+def test_get_parent_experiment(project_client):
+    project = project_client
+    parent = project.log_experiment(name="parent")
+    child = project.log_experiment(name="child")
+
+    parent.add_child_experiment(child)
+
+    assert child.get_parent_experiment().id == parent.id

--- a/tests/unit/client/test_experiment_client.py
+++ b/tests/unit/client/test_experiment_client.py
@@ -407,6 +407,19 @@ def test_add_child_experiment(project_client):
     assert f"child:{child.id}" in parent.tags
 
 
+def test_add_child_experiment_error(rubicon_and_project_client):
+    rubicon, project = rubicon_and_project_client
+    another_project = rubicon.create_project(name="another one")
+
+    parent = project.log_experiment(name="parent")
+    child = another_project.log_experiment(name="child")
+
+    with pytest.raises(RubiconException) as error:
+        parent.add_child_experiment(child)
+
+    assert "Descendents must be logged to the same project." in str(error)
+
+
 def test_get_child_experiments(project_client):
     project = project_client
     parent = project.log_experiment(name="parent")

--- a/tests/unit/client/test_experiment_client.py
+++ b/tests/unit/client/test_experiment_client.py
@@ -437,4 +437,4 @@ def test_get_parent_experiment(project_client):
 
     parent.add_child_experiment(child)
 
-    assert child.get_parent_experiment().id == parent.id
+    assert child.get_parent_experiments()[0].id == parent.id

--- a/tests/unit/client/test_experiment_client.py
+++ b/tests/unit/client/test_experiment_client.py
@@ -430,7 +430,7 @@ def test_get_child_experiments(project_client):
     assert parent.get_child_experiments()[0].id == child.id
 
 
-def test_get_parent_experiment(project_client):
+def test_get_parent_experiments(project_client):
     project = project_client
     parent = project.log_experiment(name="parent")
     child = project.log_experiment(name="child")


### PR DESCRIPTION
## What
  * adds `add_child_experiment`, `get_child_experiments`, and `get_parent_experiment`
    * leverages tagging to represent parent/child relationships among experiments

## How to Test
  * `python -m pytest tests/unit/client/test_experiment_client.py`
  * run the [new notebook](https://github.com/capitalone/rubicon-ml/blob/ccfc2bd6719c3d5877fd9da09b5cb2681327f501/notebooks/logging-examples/manage-experiment-relationships.ipynb)
