### PR TITLE
leverage Dash/Jupyterlab integration directly in `viz`

### DIFF
--- a/docs/docs-environment.yml
+++ b/docs/docs-environment.yml
@@ -17,7 +17,7 @@ dependencies:
 
   # install rubicon-ml dependencies
   # so local pip install doesn't
-  - dash<=2.14.2,>=2.0.0
+  - dash<=2.14.2,>=2.11.0
   - dash-bootstrap-components<=1.5.0,>=1.0.0
   - fsspec<=2023.12.2,>=2021.4.0
   - intake[dataframe]<=0.7.0,>=0.5.2

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - s3fs<=2023.12.2,>=0.4
 
   # for viz extras
-  - dash<=2.14.2,>=2.0.0
+  - dash<=2.14.2,>=2.11.0
   - dash-bootstrap-components<=1.5.0,>=1.0.0
 
   # for testing

--- a/rubicon_ml/viz/base.py
+++ b/rubicon_ml/viz/base.py
@@ -1,7 +1,3 @@
-import os
-import threading
-import time
-
 import dash_bootstrap_components as dbc
 from dash import Dash, html
 

--- a/rubicon_ml/viz/base.py
+++ b/rubicon_ml/viz/base.py
@@ -70,7 +70,8 @@ class VizBase:
             "external" to serve the dashboard at an external link. "tab" to serve
             the dashboard at an external link and open a new browser tab to
             said link. "jupyterlab" to render the dashboard in a new window within
-            the current Jupyter session.
+            the current Jupyterlab session. Defaults to "inline", which is a no-op
+            outside of Jupyterlab sessions.
         dash_kwargs : dict, optional
             Keyword arguments to be passed along to the newly instantiated
             Dash object. Available options can be found at
@@ -86,7 +87,7 @@ class VizBase:
         if jupyter_mode not in JUPYTER_MODES:
             raise RuntimeError(
                 f"Invalid `jupyter_mode` '{jupyter_mode}'. Must be one of "
-                f"{' '.join(JUPYTER_MODES)}"
+                f"{', '.join(JUPYTER_MODES)}"
             )
 
         if self.experiments is None:

--- a/rubicon_ml/viz/base.py
+++ b/rubicon_ml/viz/base.py
@@ -57,18 +57,22 @@ class VizBase:
             "extensions of `VizBase` must implement `register_callbacks(self)`"
         )
 
-    def serve(self, jupyter_mode="external", dash_kwargs={}, run_server_kwargs={}):
+    def serve(
+        self, in_background=False, jupyter_mode="external", dash_kwargs={}, run_server_kwargs={}
+    ):
         """Serve the Dash app on the next available port to render the visualization.
 
         Parameters
         ----------
+        in_background : bool, optional
+            DEPRECATED. Background processing is now handled by `jupyter_mode`.
         jupyter_mode : "external", "inline", "jupyterlab", or "tab", optional
             How to render the dashboard when running from Jupyterlab. "external"
             to serve the dashboard at an external link. "inline" to render the
             dashboard in the current notebook's output cell. "jupyterlab" to
-            render the dashboard in a new window within the current Jupyterlab session.
-            "tab" to serve the dashboard at an external link and open a new
-            browser tab to said link. Defaults to "external".
+            render the dashboard in a new window within the current Jupyterlab
+            session. "tab" to serve the dashboard at an external link and open a
+            new browser tab to said link. Defaults to "external".
         dash_kwargs : dict, optional
             Keyword arguments to be passed along to the newly instantiated
             Dash object. Available options can be found at
@@ -80,6 +84,12 @@ class VizBase:
             the 'port' argument can be provided here to serve the app on a
             specific port.
         """
+        if in_background:
+            warnings.warn(
+                "The `in_background` argument is deprecated and will have no effect, "
+                "Background processing is now handled by `jupyter_mode`."
+            )
+
         JUPYTER_MODES = ["external", "inline", "jupyterlab", "tab"]
         if jupyter_mode not in JUPYTER_MODES:
             raise ValueError(
@@ -121,6 +131,33 @@ class VizBase:
     def show(
         self, i_frame_kwargs={}, dash_kwargs={}, run_server_kwargs={}, height=None, width=None
     ):
+        """Serve the Dash app on the next available port to render the visualization.
+
+        Additionally, renders the visualization inline in the current Jupyter notebook.
+
+        Parameters
+        ----------
+        i_frame_kwargs: dict, optional
+            DEPRECATED. Use `height` and `width` instead.
+        dash_kwargs : dict, optional
+            Keyword arguments to be passed along to the newly instantiated
+            Dash object. Available options can be found at
+            https://dash.plotly.com/reference#dash.dash.
+        run_server_kwargs : dict, optional
+            Keyword arguments to be passed along to `Dash.run_server`.
+            Available options can be found at
+            https://dash.plotly.com/reference#app.run_server. Most commonly,
+            the 'port' argument can be provided here to serve the app on a
+            specific port.
+        height : int, str or None, optional
+            The height of the inline visualizaiton. Integers represent number
+            of pixels, strings represent a percentage of the window and must
+            end with '%'.
+        width : int, str or None, optional
+            The width of the inline visualizaiton. Integers represent number
+            of pixels, strings represent a percentage of the window and must
+            end with '%'.
+        """
         if i_frame_kwargs:
             warnings.warn(
                 "The `i_frame_kwargs` argument is deprecated and will have no effect, "

--- a/rubicon_ml/viz/base.py
+++ b/rubicon_ml/viz/base.py
@@ -18,7 +18,7 @@ class VizBase:
 
     def __init__(
         self,
-        dash_title: Optional[str] = "base",
+        dash_title: str = "base",
     ):
         self.dash_title = f"rubicon-ml: {dash_title}"
 
@@ -53,17 +53,17 @@ class VizBase:
             "extensions of `VizBase` must implement `load_experiment_data(self)`"
         )
 
-    def register_callbacks(self, link_experiment_table: Optional[bool] = False):
+    def register_callbacks(self, link_experiment_table: bool = False):
         raise NotImplementedError(
             "extensions of `VizBase` must implement `register_callbacks(self)`"
         )
 
     def serve(
         self,
-        in_background: Optional[bool] = False,
-        jupyter_mode: Optional[Literal["external", "inline", "jupyterlab", "tab"]] = "external",
-        dash_kwargs: Optional[Dict] = {},
-        run_server_kwargs: Optional[Dict] = {},
+        in_background: bool = False,
+        jupyter_mode: Literal["external", "inline", "jupyterlab", "tab"] = "external",
+        dash_kwargs: Dict = {},
+        run_server_kwargs: Dict = {},
     ):
         """Serve the Dash app on the next available port to render the visualization.
 
@@ -139,11 +139,11 @@ class VizBase:
 
     def show(
         self,
-        i_frame_kwargs: Optional[Dict] = {},
-        dash_kwargs: Optional[Dict] = {},
-        run_server_kwargs: Optional[Dict] = {},
-        height: Optional[Union[bool, None]] = None,
-        width: Optional[Union[bool, None]] = None,
+        i_frame_kwargs: Dict = {},
+        dash_kwargs: Dict = {},
+        run_server_kwargs: Dict = {},
+        height: Optional[Union[int, str]] = None,
+        width: Optional[Union[int, str]] = None,
     ):
         """Serve the Dash app on the next available port to render the visualization.
 

--- a/rubicon_ml/viz/base.py
+++ b/rubicon_ml/viz/base.py
@@ -1,3 +1,5 @@
+import warnings
+
 import dash_bootstrap_components as dbc
 from dash import Dash, html
 
@@ -55,19 +57,18 @@ class VizBase:
             "extensions of `VizBase` must implement `register_callbacks(self)`"
         )
 
-    def serve(self, jupyter_mode="inline", dash_kwargs={}, run_server_kwargs={}):
+    def serve(self, jupyter_mode="external", dash_kwargs={}, run_server_kwargs={}):
         """Serve the Dash app on the next available port to render the visualization.
 
         Parameters
         ----------
         jupyter_mode : "external", "inline", "jupyterlab", or "tab", optional
-            How to render the dashboard when running from Jupyterlab. "inline"
-            to render the dashboard in the current notebook's output cell.
-            "external" to serve the dashboard at an external link. "tab" to serve
-            the dashboard at an external link and open a new browser tab to
-            said link. "jupyterlab" to render the dashboard in a new window within
-            the current Jupyterlab session. Defaults to "inline", which is a no-op
-            outside of Jupyterlab sessions.
+            How to render the dashboard when running from Jupyterlab. "external"
+            to serve the dashboard at an external link. "inline" to render the
+            dashboard in the current notebook's output cell. "jupyterlab" to
+            render the dashboard in a new window within the current Jupyterlab session.
+            "tab" to serve the dashboard at an external link and open a new
+            browser tab to said link. Defaults to "external".
         dash_kwargs : dict, optional
             Keyword arguments to be passed along to the newly instantiated
             Dash object. Available options can be found at
@@ -116,3 +117,23 @@ class VizBase:
         _next_available_port = default_run_server_kwargs["port"] + 1
 
         self.app.run_server(**default_run_server_kwargs)
+
+    def show(
+        self, i_frame_kwargs={}, dash_kwargs={}, run_server_kwargs={}, height=None, width=None
+    ):
+        if i_frame_kwargs:
+            warnings.warn(
+                "The `i_frame_kwargs` argument is deprecated and will have no effect, "
+                "use `height` and `width` instead."
+            )
+
+        if height is not None:
+            run_server_kwargs["jupyter_height"] = height
+        if width is not None:
+            run_server_kwargs["jupyter_width"] = width
+
+        self.serve(
+            jupyter_mode="inline",
+            dash_kwargs=dash_kwargs,
+            run_server_kwargs=run_server_kwargs,
+        )

--- a/rubicon_ml/viz/base.py
+++ b/rubicon_ml/viz/base.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import Dict, Literal, Optional, Union
 
 import dash_bootstrap_components as dbc
 from dash import Dash, html
@@ -17,7 +18,7 @@ class VizBase:
 
     def __init__(
         self,
-        dash_title="base",
+        dash_title: Optional[str] = "base",
     ):
         self.dash_title = f"rubicon-ml: {dash_title}"
 
@@ -52,13 +53,17 @@ class VizBase:
             "extensions of `VizBase` must implement `load_experiment_data(self)`"
         )
 
-    def register_callbacks(self, link_experiment_table=False):
+    def register_callbacks(self, link_experiment_table: Optional[bool] = False):
         raise NotImplementedError(
             "extensions of `VizBase` must implement `register_callbacks(self)`"
         )
 
     def serve(
-        self, in_background=False, jupyter_mode="external", dash_kwargs={}, run_server_kwargs={}
+        self,
+        in_background: Optional[bool] = False,
+        jupyter_mode: Optional[Literal["external", "inline", "jupyterlab", "tab"]] = "external",
+        dash_kwargs: Optional[Dict] = {},
+        run_server_kwargs: Optional[Dict] = {},
     ):
         """Serve the Dash app on the next available port to render the visualization.
 
@@ -133,7 +138,12 @@ class VizBase:
         self.app.run(**default_run_server_kwargs)
 
     def show(
-        self, i_frame_kwargs={}, dash_kwargs={}, run_server_kwargs={}, height=None, width=None
+        self,
+        i_frame_kwargs: Optional[Dict] = {},
+        dash_kwargs: Optional[Dict] = {},
+        run_server_kwargs: Optional[Dict] = {},
+        height: Optional[Union[bool, None]] = None,
+        width: Optional[Union[bool, None]] = None,
     ):
         """Serve the Dash app on the next available port to render the visualization.
 

--- a/rubicon_ml/viz/base.py
+++ b/rubicon_ml/viz/base.py
@@ -126,7 +126,7 @@ class VizBase:
 
         _next_available_port = default_run_server_kwargs["port"] + 1
 
-        self.app.run_server(**default_run_server_kwargs)
+        self.app.run(**default_run_server_kwargs)
 
     def show(
         self, i_frame_kwargs={}, dash_kwargs={}, run_server_kwargs={}, height=None, width=None

--- a/rubicon_ml/viz/base.py
+++ b/rubicon_ml/viz/base.py
@@ -90,7 +90,8 @@ class VizBase:
         if in_background:
             warnings.warn(
                 "The `in_background` argument is deprecated and will have no effect, "
-                "Background processing is now handled by `jupyter_mode`."
+                "Background processing is now handled by `jupyter_mode`.",
+                DeprecationWarning,
             )
 
         JUPYTER_MODES = ["external", "inline", "jupyterlab", "tab"]
@@ -164,7 +165,8 @@ class VizBase:
         if i_frame_kwargs:
             warnings.warn(
                 "The `i_frame_kwargs` argument is deprecated and will have no effect, "
-                "use `height` and `width` instead."
+                "use `height` and `width` instead.",
+                DeprecationWarning,
             )
 
         if height is not None:

--- a/rubicon_ml/viz/base.py
+++ b/rubicon_ml/viz/base.py
@@ -85,7 +85,7 @@ class VizBase:
         """
         JUPYTER_MODES = ["external", "inline", "jupyterlab", "tab"]
         if jupyter_mode not in JUPYTER_MODES:
-            raise RuntimeError(
+            raise ValueError(
                 f"Invalid `jupyter_mode` '{jupyter_mode}'. Must be one of "
                 f"{', '.join(JUPYTER_MODES)}"
             )

--- a/rubicon_ml/viz/base.py
+++ b/rubicon_ml/viz/base.py
@@ -67,12 +67,15 @@ class VizBase:
         in_background : bool, optional
             DEPRECATED. Background processing is now handled by `jupyter_mode`.
         jupyter_mode : "external", "inline", "jupyterlab", or "tab", optional
-            How to render the dashboard when running from Jupyterlab. "external"
-            to serve the dashboard at an external link. "inline" to render the
-            dashboard in the current notebook's output cell. "jupyterlab" to
-            render the dashboard in a new window within the current Jupyterlab
-            session. "tab" to serve the dashboard at an external link and open a
-            new browser tab to said link. Defaults to "external".
+            How to render the dashboard when running from Jupyterlab.
+            * "external" to serve the dashboard at an external link.
+            * "inline" to render the dashboard in the current notebook's output
+              cell.
+            * "jupyterlab" to render the dashboard in a new window within the
+              current Jupyterlab session.
+            * "tab" to serve the dashboard at an external link and open a new
+              browser tab to said link.
+            Defaults to "external".
         dash_kwargs : dict, optional
             Keyword arguments to be passed along to the newly instantiated
             Dash object. Available options can be found at

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,13 +44,13 @@ prefect =
 s3 = 
 	s3fs<=2023.12.2,>=0.4
 ui = 
-	dash<=2.14.2,>=2.0.0
+	dash<=2.14.2,>=2.11.0
 	dash-bootstrap-components<=1.5.0,>=1.0.0
 viz = 
-	dash<=2.14.2,>=2.0.0
+	dash<=2.14.2,>=2.11.0
 	dash-bootstrap-components<=1.5.0,>=1.0.0
 all = 
-	dash<=2.14.2,>=2.0.0
+	dash<=2.14.2,>=2.11.0
 	dash-bootstrap-components<=1.5.0,>=1.0.0
 	prefect<=1.2.4,>=0.12.0
 	s3fs<=2023.12.2,>=0.4

--- a/tests/unit/viz/test_base.py
+++ b/tests/unit/viz/test_base.py
@@ -1,3 +1,4 @@
+import pytest
 from dash import Dash, html
 
 from rubicon_ml.viz.base import VizBase
@@ -19,3 +20,24 @@ def test_base_build_layout():
 
     assert len(layout) == 8
     assert layout.children.children[-1].children.id == "test-layout"
+
+
+def test_base_serve_jupyter_mode_errors():
+    base = VizBaseTest()
+    base.build_layout()
+
+    with pytest.raises(ValueError) as error:
+        base.serve(jupyter_mode="invalid")
+
+    assert "Invalid `jupyter_mode`" in str(error)
+
+
+def test_base_serve_missing_experiment_errors():
+    base = VizBaseTest()
+    base.build_layout()
+    base.experiments = None
+
+    with pytest.raises(RuntimeError) as error:
+        base.serve()
+
+    assert "experiments` can not be None" in str(error)


### PR DESCRIPTION
## What

we've had some issues lately with the dashboard not rendering properly in Jupyterlab. we originally had a lot of boilerplate in the viz base to deal with rendering in Jupyterlab ourselves, and it appears Dash has internalized a lot of that functionality starting with version 2.11

* updates minimum dash version to 2.11
* replaces our Jupyterlab boilerplate with the `jupyter_mode` input to `app.run`
  * should be no user-facing, breaking changes
  * keeping both `serve` and `show`, noting deprecations

## How to Test
  * validate that each of the four `jupyter_modes`, "internal", "external", "tab", and "jupyterlab" properly render the visualizations from a Jupyterlab session (you can use the [experiments table notebook](https://github.com/capitalone/rubicon-ml/blob/main/notebooks/viz/experiments-table.ipynb))
  * run the tests `python -m pytest tests/unit/viz`
