### PR TITLE
add `h2o` schema

### DIFF
--- a/rubicon_ml/schema/logger.py
+++ b/rubicon_ml/schema/logger.py
@@ -181,9 +181,15 @@ class SchemaMixin:
                 if artifact == "self":
                     experiment.log_artifact(name=obj.__class__.__name__, data_object=obj)
             elif isinstance(artifact, dict):
-                data_object = _get_data_object(obj, artifact)
-                if data_object is not None:
-                    experiment.log_artifact(name=artifact["name"], data_object=data_object)
+                if "self" in artifact:
+                    logging_func_name = artifact["self"]
+                    logging_func = getattr(experiment, logging_func_name)
+                    logging_func(obj)
+                else:
+                    data_object = _get_data_object(obj, artifact)
+
+                    if data_object is not None:
+                        experiment.log_artifact(name=artifact["name"], data_object=data_object)
 
         for dataframe in self.schema_.get("dataframes", []):
             df_value = _get_df(obj, dataframe)

--- a/rubicon_ml/schema/registry.py
+++ b/rubicon_ml/schema/registry.py
@@ -12,6 +12,9 @@ RUBICON_SCHEMA_REGISTRY = {
     "h2o__H2OGradientBoostingEstimator": lambda: _load_schema(
         os.path.join("schema", "h2o__H2OGradientBoostingEstimator.yaml")
     ),
+    "h2o__H2ORandomForestEstimator": lambda: _load_schema(
+        os.path.join("schema", "h2o__H2ORandomForestEstimator.yaml")
+    ),
     "lightgbm__LGBMModel": lambda: _load_schema(os.path.join("schema", "lightgbm__LGBMModel.yaml")),
     "lightgbm__LGBMClassifier": lambda: _load_schema(
         os.path.join("schema", "lightgbm__LGBMClassifier.yaml")

--- a/rubicon_ml/schema/registry.py
+++ b/rubicon_ml/schema/registry.py
@@ -6,6 +6,9 @@ from typing import Any, List
 import yaml
 
 RUBICON_SCHEMA_REGISTRY = {
+    "h2o__H2OGradientBoostingEstimator": lambda: _load_schema(
+        os.path.join("schema", "h2o__H2OGradientBoostingEstimator.yaml")
+    ),
     "lightgbm__LGBMModel": lambda: _load_schema(os.path.join("schema", "lightgbm__LGBMModel.yaml")),
     "lightgbm__LGBMClassifier": lambda: _load_schema(
         os.path.join("schema", "lightgbm__LGBMClassifier.yaml")

--- a/rubicon_ml/schema/registry.py
+++ b/rubicon_ml/schema/registry.py
@@ -18,6 +18,9 @@ RUBICON_SCHEMA_REGISTRY = {
     "h2o__H2OTargetEncoderEstimator": lambda: _load_schema(
         os.path.join("schema", "h2o__H2OTargetEncoderEstimator.yaml")
     ),
+    "h2o__H2OXGBoostEstimator": lambda: _load_schema(
+        os.path.join("schema", "h2o__H2OXGBoostEstimator.yaml")
+    ),
     "lightgbm__LGBMModel": lambda: _load_schema(os.path.join("schema", "lightgbm__LGBMModel.yaml")),
     "lightgbm__LGBMClassifier": lambda: _load_schema(
         os.path.join("schema", "lightgbm__LGBMClassifier.yaml")

--- a/rubicon_ml/schema/registry.py
+++ b/rubicon_ml/schema/registry.py
@@ -15,6 +15,9 @@ RUBICON_SCHEMA_REGISTRY = {
     "h2o__H2ORandomForestEstimator": lambda: _load_schema(
         os.path.join("schema", "h2o__H2ORandomForestEstimator.yaml")
     ),
+    "h2o__H2OTargetEncoderEstimator": lambda: _load_schema(
+        os.path.join("schema", "h2o__H2OTargetEncoderEstimator.yaml")
+    ),
     "lightgbm__LGBMModel": lambda: _load_schema(os.path.join("schema", "lightgbm__LGBMModel.yaml")),
     "lightgbm__LGBMClassifier": lambda: _load_schema(
         os.path.join("schema", "lightgbm__LGBMClassifier.yaml")

--- a/rubicon_ml/schema/registry.py
+++ b/rubicon_ml/schema/registry.py
@@ -6,6 +6,9 @@ from typing import Any, List
 import yaml
 
 RUBICON_SCHEMA_REGISTRY = {
+    "h2o__H2OGeneralizedLinearEstimator": lambda: _load_schema(
+        os.path.join("schema", "h2o__H2OGeneralizedLinearEstimator.yaml")
+    ),
     "h2o__H2OGradientBoostingEstimator": lambda: _load_schema(
         os.path.join("schema", "h2o__H2OGradientBoostingEstimator.yaml")
     ),

--- a/rubicon_ml/schema/schema/h2o__H2OGeneralizedLinearEstimator.yaml
+++ b/rubicon_ml/schema/schema/h2o__H2OGeneralizedLinearEstimator.yaml
@@ -1,0 +1,156 @@
+name: h2o__H2OGeneralizedLinearEstimator
+version: 1.0.0
+
+compatibility:
+  lightgbm:
+    max_version:
+    min_version: 3.44.0.1
+docs_url: https://docs.h2o.ai/h2o/latest-stable/h2o-py/docs/modeling.html#h2ogeneralizedlinearestimator
+
+parameters:
+  - name: alpha
+    value_attr: alpha
+  - name: auc_type
+    value_attr: auc_type
+  - name: balance_classes
+    value_attr: balance_classes
+  - name: beta_constraints
+    value_attr: beta_constraints
+  - name: beta_epsilon
+    value_attr: beta_epsilon
+  - name: build_null_model
+    value_attr: build_null_model
+  - name: calc_like
+    value_attr: calc_like
+  - name: class_sampling_factors
+    value_attr: class_sampling_factors
+  - name: cold_start
+    value_attr: cold_start
+  - name: compute_p_values
+    value_attr: compute_p_values
+  - name: custom_metric_func
+    value_attr: custom_metric_func
+  - name: dispersion_epsilon
+    value_attr: dispersion_epsilon
+  - name: dispersion_learning_rate
+    value_attr: dispersion_learning_rate
+  - name: dispersion_parameter_method
+    value_attr: dispersion_parameter_method
+  - name: early_stopping
+    value_attr: early_stopping
+  - name: export_checkpoints_dir
+    value_attr: export_checkpoints_dir
+  - name: family
+    value_attr: family
+  - name: fix_dispersion_parameter
+    value_attr: fix_dispersion_parameter
+  - name: fix_tweedie_variance_power
+    value_attr: fix_tweedie_variance_power
+  - name: fold_assignment
+    value_attr: fold_assignment
+  - name: fold_column
+    value_attr: fold_column
+  - name: gainslift_bins
+    value_attr: gainslift_bins
+  - name: generate_scoring_history
+    value_attr: generate_scoring_history
+  - name: generate_variable_inflation_factors
+    value_attr: generate_variable_inflation_factors
+  - name: gradient_epsilon
+    value_attr: gradient_epsilon
+  - name: HGLM
+    value_attr: HGLM
+  - name: ignore_const_cols
+    value_attr: ignore_const_cols
+  - name: ignored_columns
+    value_attr: ignored_columns
+  - name: influence
+    value_attr: influence
+  - name: init_dispersion_parameter
+    value_attr: init_dispersion_parameter
+  - name: interaction_pairs
+    value_attr: interaction_pairs
+  - name: interactions
+    value_attr: interactions
+  - name: intercept
+    value_attr: intercept
+  - name: keep_cross_validation_fold_assignment
+    value_attr: keep_cross_validation_fold_assignment
+  - name: keep_cross_validation_models
+    value_attr: keep_cross_validation_models
+  - name: keep_cross_validation_predictions
+    value_attr: keep_cross_validation_predictions
+  - name: lambda_
+    value_attr: lambda_
+  - name: lambda_min_ratio
+    value_attr: lambda_min_ratio
+  - name: lambda_search
+    value_attr: lambda_search
+  - name: link
+    value_attr: link
+  - name: max_active_predictors
+    value_attr: max_active_predictors
+  - name: max_after_balance_size
+    value_attr: max_after_balance_size
+  - name: max_confusion_matrix_size
+    value_attr: max_confusion_matrix_size
+  - name: max_iterations
+    value_attr: max_iterations
+  - name: max_iterations_dispersion
+    value_attr: max_iterations_dispersion
+  - name: max_runtime_secs
+    value_attr: max_runtime_secs
+  - name: missing_values_handling
+    value_attr: missing_values_handling
+  - name: nfolds
+    value_attr: nfolds
+  - name: nlambdas
+    value_attr: nlambdas
+  - name: non_negative
+    value_attr: non_negative
+  - name: obj_reg
+    value_attr: obj_reg
+  - name: objective_epsilon
+    value_attr: objective_epsilon
+  - name: offset_column
+    value_attr: offset_column
+  - name: prior
+    value_attr: prior
+  - name: rand_family
+    value_attr: rand_family
+  - name: rand_link
+    value_attr: rand_link
+  - name: random_columns
+    value_attr: random_columns
+  - name: remove_collinear_columns
+    value_attr: remove_collinear_columns
+  - name: response_column
+    value_attr: response_column
+  - name: score_each_iteration
+    value_attr: score_each_iteration
+  - name: score_iteration_interval
+    value_attr: score_iteration_interval
+  - name: seed
+    value_attr: seed
+  - name: solver
+    value_attr: solver
+  - name: standardize
+    value_attr: standardize
+  - name: startval
+    value_attr: startval
+  - name: stopping_metric
+    value_attr: stopping_metric
+  - name: stopping_rounds
+    value_attr: stopping_rounds
+  - name: stopping_tolerance
+    value_attr: stopping_tolerance
+  - name: theta
+    value_attr: theta
+  - name: tweedie_epsilon
+    value_attr: tweedie_epsilon
+  - name: tweedie_link_power
+    value_attr: tweedie_link_power
+  - name: tweedie_variance_power
+    value_attr: tweedie_variance_power
+  - name: weights_column
+    value_attr: weights_column

--- a/rubicon_ml/schema/schema/h2o__H2OGeneralizedLinearEstimator.yaml
+++ b/rubicon_ml/schema/schema/h2o__H2OGeneralizedLinearEstimator.yaml
@@ -7,6 +7,8 @@ compatibility:
     min_version: 3.44.0.1
 docs_url: https://docs.h2o.ai/h2o/latest-stable/h2o-py/docs/modeling.html#h2ogeneralizedlinearestimator
 
+artifacts:
+  - self: log_h2o_model
 parameters:
   - name: alpha
     value_attr: alpha

--- a/rubicon_ml/schema/schema/h2o__H2OGradientBoostingEstimator.yaml
+++ b/rubicon_ml/schema/schema/h2o__H2OGradientBoostingEstimator.yaml
@@ -1,0 +1,128 @@
+name: h2o__H2OGradientBoostingEstimator 
+version: 1.0.0
+
+compatibility:
+  lightgbm:
+    max_version:
+    min_version: 3.44.0.1
+docs_url: https://docs.h2o.ai/h2o/latest-stable/h2o-py/docs/modeling.html#h2ogradientboostingestimator
+
+parameters:
+  - name: auc_type
+    value_attr: auc_type
+  - name: auto_rebalance
+    value_attr: auto_rebalance
+  - name: balance_classes
+    value_attr: balance_classes
+  - name: build_tree_one_node
+    value_attr: build_tree_one_node
+  - name: calibrate_model
+    value_attr: calibrate_model
+  - name: calibration_method
+    value_attr: calibration_method
+  - name: categorical_encoding
+    value_attr: categorical_encoding
+  - name: check_constant_response
+    value_attr: check_constant_response
+  - name: class_sampling_factors
+    value_attr: class_sampling_factors
+  - name: col_sample_rate
+    value_attr: col_sample_rate
+  - name: col_sample_rate_change_per_level
+    value_attr: col_sample_rate_change_per_level
+  - name: col_sample_rate_per_tree
+    value_attr: col_sample_rate_per_tree
+  - name: custom_distribution_func
+    value_attr: custom_distribution_func
+  - name: custom_metric_func
+    value_attr: custom_metric_func
+  - name: distribution
+    value_attr: distribution
+  - name: export_checkpoints_dir
+    value_attr: export_checkpoints_dir
+  - name: fold_assignment
+    value_attr: fold_assignment
+  - name: fold_column
+    value_attr: fold_column
+  - name: gainslift_bins
+    value_attr: gainslift_bins
+  - name: histogram_type
+    value_attr: histogram_type
+  - name: huber_alpha
+    value_attr: huber_alpha
+  - name: ignore_const_cols
+    value_attr: ignore_const_cols
+  - name: ignored_columns
+    value_attr: ignored_columns
+  - name: in_training_checkpoints_dir
+    value_attr: in_training_checkpoints_dir
+  - name: in_training_checkpoints_tree_interval
+    value_attr: in_training_checkpoints_tree_interval
+  - name: interaction_constraints
+    value_attr: interaction_constraints
+  - name: keep_cross_validation_fold_assignment
+    value_attr: keep_cross_validation_fold_assignment
+  - name: keep_cross_validation_models
+    value_attr: keep_cross_validation_models
+  - name: keep_cross_validation_predictions
+    value_attr: keep_cross_validation_predictions
+  - name: learn_rate
+    value_attr: learn_rate
+  - name: learn_rate_annealing
+    value_attr: learn_rate_annealing
+  - name: max_abs_leafnode_pred
+    value_attr: max_abs_leafnode_pred
+  - name: max_after_balance_size
+    value_attr: max_after_balance_size
+  - name: max_confusion_matrix_size
+    value_attr: max_confusion_matrix_size
+  - name: max_depth
+    value_attr: max_depth
+  - name: max_runtime_secs
+    value_attr: max_runtime_secs
+  - name: min_rows
+    value_attr: min_rows
+  - name: min_split_improvement
+    value_attr: min_split_improvement
+  - name: monotone_constraints
+    value_attr: monotone_constraints
+  - name: nbins
+    value_attr: nbins
+  - name: nbins_cats
+    value_attr: nbins_cats
+  - name: nbins_top_level
+    value_attr: nbins_top_level
+  - name: nfolds
+    value_attr: nfolds
+  - name: ntrees
+    value_attr: ntrees
+  - name: offset_column
+    value_attr: offset_column
+  - name: pred_noise_bandwidth
+    value_attr: pred_noise_bandwidth
+  - name: quantile_alpha
+    value_attr: quantile_alpha
+  - name: response_column
+    value_attr: response_column
+  - name: r2_stopping
+    value_attr: r2_stopping
+  - name: sample_rate
+    value_attr: sample_rate
+  - name: sample_rate_per_class
+    value_attr: sample_rate_per_class
+  - name: seed
+    value_attr: seed
+  - name: score_each_iteration
+    value_attr: score_each_iteration
+  - name: score_tree_interval
+    value_attr: score_tree_interval
+  - name: stopping_metric
+    value_attr: stopping_metric
+  - name: stopping_rounds
+    value_attr: stopping_rounds
+  - name: stopping_tolerance
+    value_attr: stopping_tolerance
+  - name: tweedie_power
+    value_attr: tweedie_power
+  - name: weights_column
+    value_attr: weights_column

--- a/rubicon_ml/schema/schema/h2o__H2OGradientBoostingEstimator.yaml
+++ b/rubicon_ml/schema/schema/h2o__H2OGradientBoostingEstimator.yaml
@@ -7,6 +7,8 @@ compatibility:
     min_version: 3.44.0.1
 docs_url: https://docs.h2o.ai/h2o/latest-stable/h2o-py/docs/modeling.html#h2ogradientboostingestimator
 
+artifacts:
+  - self: log_h2o_model
 parameters:
   - name: auc_type
     value_attr: auc_type

--- a/rubicon_ml/schema/schema/h2o__H2ORandomForestEstimator.yaml
+++ b/rubicon_ml/schema/schema/h2o__H2ORandomForestEstimator.yaml
@@ -7,6 +7,8 @@ compatibility:
     min_version: 3.44.0.1
 docs_url: https://docs.h2o.ai/h2o/latest-stable/h2o-py/docs/modeling.html#h2orandomforestestimator
 
+artifacts:
+  - self: log_h2o_model
 parameters:
   - name: auc_type
     value_attr: auc_type

--- a/rubicon_ml/schema/schema/h2o__H2ORandomForestEstimator.yaml
+++ b/rubicon_ml/schema/schema/h2o__H2ORandomForestEstimator.yaml
@@ -1,19 +1,19 @@
-name: h2o__H2OGradientBoostingEstimator 
+name: h2o__H2ORandomForestEstimator
 version: 1.0.0
 
 compatibility:
   lightgbm:
     max_version:
     min_version: 3.44.0.1
-docs_url: https://docs.h2o.ai/h2o/latest-stable/h2o-py/docs/modeling.html#h2ogradientboostingestimator
+docs_url: https://docs.h2o.ai/h2o/latest-stable/h2o-py/docs/modeling.html#h2orandomforestestimator
 
 parameters:
   - name: auc_type
     value_attr: auc_type
-  - name: auto_rebalance
-    value_attr: auto_rebalance
   - name: balance_classes
     value_attr: balance_classes
+  - name: binomial_double_trees
+    value_attr: binomial_double_trees
   - name: build_tree_one_node
     value_attr: build_tree_one_node
   - name: calibrate_model
@@ -26,14 +26,10 @@ parameters:
     value_attr: check_constant_response
   - name: class_sampling_factors
     value_attr: class_sampling_factors
-  - name: col_sample_rate
-    value_attr: col_sample_rate
   - name: col_sample_rate_change_per_level
     value_attr: col_sample_rate_change_per_level
   - name: col_sample_rate_per_tree
     value_attr: col_sample_rate_per_tree
-  - name: custom_distribution_func
-    value_attr: custom_distribution_func
   - name: custom_metric_func
     value_attr: custom_metric_func
   - name: distribution
@@ -48,30 +44,16 @@ parameters:
     value_attr: gainslift_bins
   - name: histogram_type
     value_attr: histogram_type
-  - name: huber_alpha
-    value_attr: huber_alpha
   - name: ignore_const_cols
     value_attr: ignore_const_cols
   - name: ignored_columns
     value_attr: ignored_columns
-  - name: in_training_checkpoints_dir
-    value_attr: in_training_checkpoints_dir
-  - name: in_training_checkpoints_tree_interval
-    value_attr: in_training_checkpoints_tree_interval
-  - name: interaction_constraints
-    value_attr: interaction_constraints
   - name: keep_cross_validation_fold_assignment
     value_attr: keep_cross_validation_fold_assignment
   - name: keep_cross_validation_models
     value_attr: keep_cross_validation_models
   - name: keep_cross_validation_predictions
     value_attr: keep_cross_validation_predictions
-  - name: learn_rate
-    value_attr: learn_rate
-  - name: learn_rate_annealing
-    value_attr: learn_rate_annealing
-  - name: max_abs_leafnode_pred
-    value_attr: max_abs_leafnode_pred
   - name: max_after_balance_size
     value_attr: max_after_balance_size
   - name: max_confusion_matrix_size
@@ -84,8 +66,8 @@ parameters:
     value_attr: min_rows
   - name: min_split_improvement
     value_attr: min_split_improvement
-  - name: monotone_constraints
-    value_attr: monotone_constraints
+  - name: mtries
+    value_attr: mtries
   - name: nbins
     value_attr: nbins
   - name: nbins_cats
@@ -98,10 +80,6 @@ parameters:
     value_attr: ntrees
   - name: offset_column
     value_attr: offset_column
-  - name: pred_noise_bandwidth
-    value_attr: pred_noise_bandwidth
-  - name: quantile_alpha
-    value_attr: quantile_alpha
   - name: r2_stopping
     value_attr: r2_stopping
   - name: response_column
@@ -122,7 +100,5 @@ parameters:
     value_attr: stopping_rounds
   - name: stopping_tolerance
     value_attr: stopping_tolerance
-  - name: tweedie_power
-    value_attr: tweedie_power
   - name: weights_column
     value_attr: weights_column

--- a/rubicon_ml/schema/schema/h2o__H2OTargetEncoderEstimator.yaml
+++ b/rubicon_ml/schema/schema/h2o__H2OTargetEncoderEstimator.yaml
@@ -7,6 +7,8 @@ compatibility:
     min_version: 3.44.0.1
 docs_url: https://docs.h2o.ai/h2o/latest-stable/h2o-py/docs/modeling.html#h2otargetencoderestimator
 
+artifacts:
+  - self: log_h2o_model
 parameters:
   - name: blending
     value_attr: blending

--- a/rubicon_ml/schema/schema/h2o__H2OTargetEncoderEstimator.yaml
+++ b/rubicon_ml/schema/schema/h2o__H2OTargetEncoderEstimator.yaml
@@ -1,0 +1,32 @@
+name: h2o__H2OTargetEncoderEstimator
+version: 1.0.0
+
+compatibility:
+  lightgbm:
+    max_version:
+    min_version: 3.44.0.1
+docs_url: https://docs.h2o.ai/h2o/latest-stable/h2o-py/docs/modeling.html#h2otargetencoderestimator
+
+parameters:
+  - name: blending
+    value_attr: blending
+  - name: columns_to_encode
+    value_attr: columns_to_encode
+  - name: data_leakage_handling
+    value_attr: data_leakage_handling
+  - name: fold_column
+    value_attr: fold_column
+  - name: ignored_columns
+    value_attr: ignored_columns
+  - name: inflection_point
+    value_attr: inflection_point
+  - name: keep_original_categorical_columns
+    value_attr: keep_original_categorical_columns
+  - name: noise
+    value_attr: noise
+  - name: response_column
+    value_attr: response_column
+  - name: seed
+    value_attr: seed
+  - name: smoothing
+    value_attr: smoothing

--- a/rubicon_ml/schema/schema/h2o__H2OXGBoostEstimator.yaml
+++ b/rubicon_ml/schema/schema/h2o__H2OXGBoostEstimator.yaml
@@ -1,0 +1,143 @@
+name: h2o__H2OXGBoostEstimator
+version: 1.0.0
+
+compatibility:
+  lightgbm:
+    max_version:
+    min_version: 3.44.0.1
+docs_url: https://docs.h2o.ai/h2o/latest-stable/h2o-py/docs/modeling.html#h2oxgboostestimator
+
+parameters:
+  - name: auc_type
+    value_attr: auc_type
+  - name: backend
+    value_attr: backend
+  - name: booster
+    value_attr: booster
+  - name: build_tree_one_node
+    value_attr: build_tree_one_node
+  - name: calibrate_model
+    value_attr: calibrate_model
+  - name: calibration_method
+    value_attr: calibration_method
+  - name: categorical_encoding
+    value_attr: categorical_encoding
+  - name: col_sample_rate
+    value_attr: col_sample_rate
+  - name: col_sample_rate_per_tree
+    value_attr: col_sample_rate_per_tree
+  - name: colsample_bylevel
+    value_attr: colsample_bylevel
+  - name: colsample_bynode
+    value_attr: colsample_bynode
+  - name: colsample_bytree
+    value_attr: colsample_bytree
+  - name: distribution
+    value_attr: distribution
+  - name: dmatrix_type
+    value_attr: dmatrix_type
+  - name: eta
+    value_attr: eta
+  - name: eval_metric
+    value_attr: eval_metric
+  - name: export_checkpoints_dir
+    value_attr: export_checkpoints_dir
+  - name: fold_assignment
+    value_attr: fold_assignment
+  - name: fold_column
+    value_attr: fold_column
+  - name: gainslift_bins
+    value_attr: gainslift_bins
+  - name: gamma
+    value_attr: gamma
+  - name: gpu_id
+    value_attr: gpu_id
+  - name: grow_policy
+    value_attr: grow_policy
+  - name: ignore_const_cols
+    value_attr: ignore_const_cols
+  - name: ignored_columns
+    value_attr: ignored_columns
+  - name: interaction_constraints
+    value_attr: interaction_constraints
+  - name: keep_cross_validation_fold_assignment
+    value_attr: keep_cross_validation_fold_assignment
+  - name: keep_cross_validation_models
+    value_attr: keep_cross_validation_models
+  - name: keep_cross_validation_predictions
+    value_attr: keep_cross_validation_predictions
+  - name: learn_rate
+    value_attr: learn_rate
+  - name: max_abs_leafnode_pred
+    value_attr: max_abs_leafnode_pred
+  - name: max_bins
+    value_attr: max_bins
+  - name: max_delta_step
+    value_attr: max_delta_step
+  - name: max_depth
+    value_attr: max_depth
+  - name: max_leaves
+    value_attr: max_leaves
+  - name: max_runtime_secs
+    value_attr: max_runtime_secs
+  - name: min_child_weight
+    value_attr: min_child_weight
+  - name: min_rows
+    value_attr: min_rows
+  - name: monotone_constraints
+    value_attr: monotone_constraints
+  - name: nfolds
+    value_attr: nfolds
+  - name: normalize_type
+    value_attr: normalize_type
+  - name: nthread
+    value_attr: nthread
+  - name: ntrees
+    value_attr: ntrees
+  - name: offset_column
+    value_attr: offset_column
+  - name: one_drop
+    value_attr: one_drop
+  - name: parallelize_cross_validation
+    value_attr: parallelize_cross_validation
+  - name: quiet_mode
+    value_attr: quiet_mode
+  - name: rate_drop
+    value_attr: rate_drop
+  - name: reg_alpha
+    value_attr: reg_alpha
+  - name: reg_lambda
+    value_attr: reg_lambda
+  - name: response_column
+    value_attr: response_column
+  - name: sample_rate
+    value_attr: sample_rate
+  - name: sample_type
+    value_attr: sample_type
+  - name: save_matrix_directory
+    value_attr: save_matrix_directory
+  - name: scale_pos_weight
+    value_attr: scale_pos_weight
+  - name: score_each_iteration
+    value_attr: score_each_iteration
+  - name: score_eval_metric_only
+    value_attr: score_eval_metric_only
+  - name: score_tree_interval
+    value_attr: score_tree_interval
+  - name: seed
+    value_attr: seed
+  - name: skip_drop
+    value_attr: skip_drop
+  - name: stopping_metric
+    value_attr: stopping_metric
+  - name: stopping_rounds
+    value_attr: stopping_rounds
+  - name: stopping_tolerance
+    value_attr: stopping_tolerance
+  - name: subsample
+    value_attr: subsample
+  - name: tree_method
+    value_attr: tree_method
+  - name: tweedie_power
+    value_attr: tweedie_power
+  - name: weights_column

--- a/rubicon_ml/schema/schema/h2o__H2OXGBoostEstimator.yaml
+++ b/rubicon_ml/schema/schema/h2o__H2OXGBoostEstimator.yaml
@@ -7,6 +7,8 @@ compatibility:
     min_version: 3.44.0.1
 docs_url: https://docs.h2o.ai/h2o/latest-stable/h2o-py/docs/modeling.html#h2oxgboostestimator
 
+artifacts:
+  - self: log_h2o_model
 parameters:
   - name: auc_type
     value_attr: auc_type

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -318,6 +318,7 @@ def artifact_schema():
     return {
         "artifacts": [
             "self",
+            {"self": "custom_logging_func"},
             {"name": "object_", "data_object_attr": "object_"},
             {"name": "object_b", "data_object_func": "artifact_function"},
         ]

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -318,7 +318,6 @@ def artifact_schema():
     return {
         "artifacts": [
             "self",
-            {"self": "custom_logging_func"},
             {"name": "object_", "data_object_attr": "object_"},
             {"name": "object_b", "data_object_func": "artifact_function"},
         ]

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -6,17 +6,12 @@ from h2o.estimators.gbm import H2OGradientBoostingEstimator
 from h2o.estimators.glm import H2OGeneralizedLinearEstimator
 from h2o.estimators.random_forest import H2ORandomForestEstimator
 from h2o.estimators.targetencoder import H2OTargetEncoderEstimator
+from h2o.estimators.xgboost import H2OXGBoostEstimator
 from lightgbm import LGBMClassifier, LGBMRegressor
 from sklearn.ensemble import RandomForestClassifier
 from xgboost import XGBClassifier, XGBRegressor
 from xgboost.dask import DaskXGBClassifier, DaskXGBRegressor
 
-H2O_SCHEMA_CLS = [
-    H2OGeneralizedLinearEstimator,
-    H2OGradientBoostingEstimator,
-    H2ORandomForestEstimator,
-    H2OTargetEncoderEstimator,
-]
 PANDAS_SCHEMA_CLS = [
     LGBMClassifier,
     LGBMRegressor,
@@ -25,6 +20,17 @@ PANDAS_SCHEMA_CLS = [
     XGBRegressor,
 ]
 DASK_SCHEMA_CLS = [DaskXGBClassifier, DaskXGBRegressor]
+H2O_SCHEMA_CLS = [
+    H2OGeneralizedLinearEstimator,
+    H2OGradientBoostingEstimator,
+    H2ORandomForestEstimator,
+    H2OTargetEncoderEstimator,
+]
+
+h2o.init()
+
+if H2OXGBoostEstimator.available():
+    H2O_SCHEMA_CLS.append(H2OXGBoostEstimator)
 
 
 def _fit_and_log(X, y, schema_cls, rubicon_project):
@@ -94,8 +100,6 @@ def test_estimator_schema_fit_dask_df(
 def test_estimator_h2o_schema_train(schema_cls, make_classification_df, rubicon_project):
     X, y = make_classification_df
     y = y > y.mean()
-
-    h2o.init(nthreads=-1)
 
     experiment = _train_and_log(X, y, schema_cls, rubicon_project)
 

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -1,9 +1,14 @@
+import h2o
+import pandas as pd
 import pytest
+from h2o import H2OFrame
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
 from lightgbm import LGBMClassifier, LGBMRegressor
 from sklearn.ensemble import RandomForestClassifier
 from xgboost import XGBClassifier, XGBRegressor
 from xgboost.dask import DaskXGBClassifier, DaskXGBRegressor
 
+H2O_SCHEMA_CLS = [H2OGradientBoostingEstimator]
 PANDAS_SCHEMA_CLS = [
     LGBMClassifier,
     LGBMRegressor,
@@ -17,6 +22,22 @@ DASK_SCHEMA_CLS = [DaskXGBClassifier, DaskXGBRegressor]
 def _fit_and_log(X, y, schema_cls, rubicon_project):
     model = schema_cls()
     model.fit(X, y)
+
+    rubicon_project.log_with_schema(model)
+
+
+def _train_and_log(X, y, schema_cls, rubicon_project):
+    target_name = "target"
+    training_frame = pd.concat([X, pd.Series(y)], axis=1)
+    training_frame.columns = [*X.columns, target_name]
+    training_frame_h2o = H2OFrame(training_frame)
+
+    model = schema_cls()
+    model.train(
+        training_frame=training_frame_h2o,
+        x=list(X.columns),
+        y=target_name,
+    )
 
     rubicon_project.log_with_schema(model)
 
@@ -58,3 +79,14 @@ def test_estimator_schema_fit_dask_df(
     X_df, y_da = make_classification_dask_df
 
     _fit_and_log(X_df, y_da, schema_cls, rubicon_project)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("schema_cls", H2O_SCHEMA_CLS)
+def test_estimator_h2o_schema_fit_df(schema_cls, make_classification_df, rubicon_project):
+    X, y = make_classification_df
+    y = y > y.mean()
+
+    h2o.init(nthreads=-1)
+
+    _train_and_log(X, y, schema_cls, rubicon_project)

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -4,6 +4,7 @@ import pytest
 from h2o import H2OFrame
 from h2o.estimators.gbm import H2OGradientBoostingEstimator
 from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+from h2o.estimators.random_forest import H2ORandomForestEstimator
 from lightgbm import LGBMClassifier, LGBMRegressor
 from sklearn.ensemble import RandomForestClassifier
 from xgboost import XGBClassifier, XGBRegressor
@@ -12,6 +13,7 @@ from xgboost.dask import DaskXGBClassifier, DaskXGBRegressor
 H2O_SCHEMA_CLS = [
     H2OGeneralizedLinearEstimator,
     H2OGradientBoostingEstimator,
+    H2ORandomForestEstimator,
 ]
 PANDAS_SCHEMA_CLS = [
     LGBMClassifier,

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -5,6 +5,7 @@ from h2o import H2OFrame
 from h2o.estimators.gbm import H2OGradientBoostingEstimator
 from h2o.estimators.glm import H2OGeneralizedLinearEstimator
 from h2o.estimators.random_forest import H2ORandomForestEstimator
+from h2o.estimators.targetencoder import H2OTargetEncoderEstimator
 from lightgbm import LGBMClassifier, LGBMRegressor
 from sklearn.ensemble import RandomForestClassifier
 from xgboost import XGBClassifier, XGBRegressor
@@ -14,6 +15,7 @@ H2O_SCHEMA_CLS = [
     H2OGeneralizedLinearEstimator,
     H2OGradientBoostingEstimator,
     H2ORandomForestEstimator,
+    H2OTargetEncoderEstimator,
 ]
 PANDAS_SCHEMA_CLS = [
     LGBMClassifier,

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -97,10 +97,18 @@ def test_estimator_schema_fit_dask_df(
 
 @pytest.mark.integration
 @pytest.mark.parametrize("schema_cls", H2O_SCHEMA_CLS)
-def test_estimator_h2o_schema_train(schema_cls, make_classification_df, rubicon_project):
+def test_estimator_h2o_schema_train(
+    schema_cls,
+    make_classification_df,
+    rubicon_local_filesystem_client_with_project,
+):
+    _, project = rubicon_local_filesystem_client_with_project
+
     X, y = make_classification_df
     y = y > y.mean()
 
-    experiment = _train_and_log(X, y, schema_cls, rubicon_project)
+    experiment = _train_and_log(X, y, schema_cls, project)
+    model_artifact = experiment.artifact(name=schema_cls.__name__)
 
-    assert len(rubicon_project.schema_["parameters"]) == len(experiment.parameters())
+    assert len(project.schema_["parameters"]) == len(experiment.parameters())
+    assert model_artifact.get_data(deserialize="h2o").__class__.__name__ == schema_cls.__name__

--- a/tests/unit/schema/test_schema_logger.py
+++ b/tests/unit/schema/test_schema_logger.py
@@ -113,6 +113,8 @@ def test_log_artifacts_with_schema(objects_to_log, rubicon_project, artifact_sch
     def custom_logging_func(self, obj):
         self.custom_logging_func_called = True
 
+    artifact_schema["artifacts"].append({"self": "custom_logging_func"})
+
     with mock.patch.object(
         rubicon_ml.client.experiment.Experiment,
         "custom_logging_func",
@@ -123,8 +125,8 @@ def test_log_artifacts_with_schema(objects_to_log, rubicon_project, artifact_sch
         experiment = rubicon_project.log_with_schema(object_to_log)
 
     otl_artifact = experiment.artifact(name=otl_cls.__name__)
-    ao_artifact = experiment.artifact(name=artifact_schema["artifacts"][2]["name"])
-    obj_b_artifact = experiment.artifact(name=artifact_schema["artifacts"][3]["name"])
+    ao_artifact = experiment.artifact(name=artifact_schema["artifacts"][1]["name"])
+    obj_b_artifact = experiment.artifact(name=artifact_schema["artifacts"][2]["name"])
 
     assert experiment.custom_logging_func_called
     assert isinstance(otl_artifact.get_data(unpickle=True), otl_cls)


### PR DESCRIPTION
## What
  * adds the ability for `self` artifacts to be logged with `Experiment` methods other than `log_artifact`
    * required to use `log_h2o_model` from #415 
  * adding schema for some `h2o` models
    * [x] `H2OGeneralizedLinearEstimator`
    * [x] `H2OGradientBoostingEstimator`
    * [x] `H2ORandomForestEstimator`
    * [x] `H2OTargetEncoderEstimator`
    * [x] `H2OXGBoostEstimator`

## How to Test
  * `python -m pytest tests/integration/test_schema.py`
