### PR TITLE
log `h2o` models as artifacts

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,7 @@ dependencies:
   - black
   - dask
   - flake8
+  - h2o-py
   - ipykernel
   - isort
   - jupyterlab

--- a/rubicon_ml/client/artifact.py
+++ b/rubicon_ml/client/artifact.py
@@ -82,8 +82,8 @@ class Artifact(Base, TagMixin):
             * "h2o" to use `h2o.load_model` to load the data.
             Defaults to None.
         unpickle : bool, optional
-            Flag indicating whether artifact data must be
-            unpickled. Will be returned as bytes by default.
+            Flag indicating whether or not to unpickle artifact data.
+            `deserialize` takes precedence. Defaults to False.
         """
         project_name, experiment_id = self.parent._get_identifiers()
         return_err = None
@@ -100,8 +100,7 @@ class Artifact(Base, TagMixin):
                     data = h2o.load_model(
                         repo._get_artifact_data_path(project_name, experiment_id, self.id)
                     )
-
-                if unpickle:
+                elif unpickle:
                     data = pickle.loads(data)
 
                 return data
@@ -110,8 +109,7 @@ class Artifact(Base, TagMixin):
 
     @failsafe
     def get_json(self):
-        data = self.get_data()
-        return json.loads(data)
+        return json.loads(self.get_data())
 
     @failsafe
     def download(self, location: Optional[str] = None, name: Optional[str] = None):

--- a/rubicon_ml/client/artifact.py
+++ b/rubicon_ml/client/artifact.py
@@ -4,7 +4,7 @@ import json
 import os
 import pickle
 import warnings
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Literal, Optional
 
 import fsspec
 
@@ -66,12 +66,21 @@ class Artifact(Base, TagMixin):
             self._raise_rubicon_exception(return_err)
 
     @failsafe
-    def get_data(self, unpickle: bool = False):
+    def get_data(
+        self,
+        deserialize: Optional[Literal["h2o"]] = None,
+        unpickle: bool = False,  # TODO: deprecate & move to `deserialize`
+    ):
         """Loads the data associated with this artifact and
         unpickles if needed.
 
         Parameters
         ----------
+        deseralize : str, optional
+            Method to use to deseralize this artifact's data.
+            * None to disable deseralization and return the raw data.
+            * "h2o" to use `h2o.load_model` to load the data.
+            Defaults to None.
         unpickle : bool, optional
             Flag indicating whether artifact data must be
             unpickled. Will be returned as bytes by default.
@@ -85,8 +94,16 @@ class Artifact(Base, TagMixin):
             except Exception as err:
                 return_err = err
             else:
+                if deserialize == "h2o":
+                    import h2o
+
+                    data = h2o.load_model(
+                        repo._get_artifact_data_path(project_name, experiment_id, self.id)
+                    )
+
                 if unpickle:
                     data = pickle.loads(data)
+
                 return data
 
         self._raise_rubicon_exception(return_err)

--- a/rubicon_ml/client/mixin.py
+++ b/rubicon_ml/client/mixin.py
@@ -213,14 +213,18 @@ class ArtifactMixin:
         """
         import h2o
 
+        if self.repository.PROTOCOL == "memory":
+            raise RubiconException("`h2o` models cannot be logged in memory with `log_h2o_model`.")
+
         if artifact_name is None:
             artifact_name = h2o_model.__class__.__name__
 
         with tempfile.TemporaryDirectory() as temp_dir_name:
             model_data_path = h2o.save_model(
                 h2o_model,
-                path=temp_dir_name,
                 export_cross_validation_predictions=export_cross_validation_predictions,
+                filename=artifact_name,
+                path=temp_dir_name,
             )
 
             artifact = self.log_artifact(


### PR DESCRIPTION
## What
  * adds `log_h2o_model` to the artifact mixin, allowing projects and experiments to log `h2o` models as artifacts
    * `h2o` models cannot be pickled - they must be logged with `h2o.save_model`
    * there are other models that follow a similar pattern - we should see if this is more generalizable in the future

## How to Test
  * `python -m pytest`
