### PR TITLE
log zipped directories as artifacts

### DIFF
--- a/rubicon_ml/client/artifact.py
+++ b/rubicon_ml/client/artifact.py
@@ -171,6 +171,13 @@ class Artifact(Base, TagMixin, CommentMixin):
         unzip : bool, optional
             True to unzip the artifact data. False otherwise.
             Defaults to False.
+
+        Yields
+        ------
+        file
+            An open file pointer into the directory the artifact data was
+            temporarily downloaded into. If the artifact is a single file,
+            its name is stored in the `artifact.name` attribute.
         """
         with tempfile.TemporaryDirectory() as temp_dir:
             self.download(location=temp_dir, unzip=unzip)

--- a/rubicon_ml/client/artifact.py
+++ b/rubicon_ml/client/artifact.py
@@ -137,8 +137,6 @@ class Artifact(Base, TagMixin, CommentMixin):
             True to unzip the artifact data. False otherwise.
             Defaults to False.
         """
-        project_name, experiment_id = self.parent._get_identifiers()
-
         if location is None:
             location = os.getcwd()
 
@@ -162,6 +160,22 @@ class Artifact(Base, TagMixin, CommentMixin):
             if unzip:
                 with zipfile.ZipFile(location_path, "r") as zip_file:
                     zip_file.extractall(location)
+
+    @contextlib.contextmanager
+    @failsafe
+    def temporary_download(self, unzip: bool = False):
+        """Temporarily download this artifact's data within a context manager.
+
+        Parameters
+        ----------
+        unzip : bool, optional
+            True to unzip the artifact data. False otherwise.
+            Defaults to False.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.download(location=temp_dir, unzip=unzip)
+
+            yield temp_dir
 
     @property
     def id(self) -> str:

--- a/tests/unit/client/test_mixin_client.py
+++ b/tests/unit/client/test_mixin_client.py
@@ -74,7 +74,8 @@ def test_log_artifact_throws_error_if_data_missing(project_client):
         ArtifactMixin.log_artifact(project, name="test.txt")
 
     assert (
-        "One of `data_bytes`, `data_file`, `data_object` or `data_path` must be provided." in str(e)
+        "One of `data_bytes`, `data_directory`, `data_file`, `data_object` "
+        "or `data_path` must be provided." in str(e)
     )
 
 


### PR DESCRIPTION
## What
  * log zipped directories as artifacts with `log_artifact(data_directory=...)`
  * unzip downloaded artifacts with `artifact.download(unzip=True)`
  * temporarily download artifact data with `artifact.temporary_download(...)`

## How to Test
 - `python -m pytest tests/unit/client/test_mixin_client.py tests/unit/client/test_artifact_client.py`
