### PR TITLE
dask bugfix

### DIFF
--- a/docs/docs-environment.yml
+++ b/docs/docs-environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - dash<=2.15.0,>=2.11.0
   - dash-bootstrap-components<=1.5.0,>=1.0.0
   - fsspec<=2024.2.0,>=2021.4.0
-  - intake[dataframe]<=2.0.3,>=0.5.2
+  - intake<=2.0.3,>=0.5.2
   - jsonpath-ng<=1.6.1,>=1.5.3
   - numpy<=1.26.4,>=1.22.0
   - pandas<=2.2.1,>=1.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 
   - click<=8.1.7,>=7.1
   - fsspec<=2024.2.0,>=2021.4.0
-  - intake[dataframe]<=2.0.3,>=0.5.2
+  - intake<=2.0.3,>=0.5.2
   - jsonpath-ng<=1.6.1,>=1.5.3
   - numpy<=1.26.4,>=1.22.0
   - pandas<=2.2.1,>=1.0.0
@@ -27,7 +27,7 @@ dependencies:
 
   # for testing
   - black
-  - dask
+  - dask[dataframe]
   - flake8
   - h2o-py
   - ipykernel

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ packages = find:
 install_requires = 
 	click<=8.1.7,>=7.1
 	fsspec<=2024.2.0,>=2021.4.0
-	intake[dataframe]<=2.0.3,>=0.5.2
+	intake<=2.0.3,>=0.5.2
 	jsonpath-ng<=1.6.1,>=1.5.3
 	numpy<=1.26.4,>=1.22.0
 	pandas<=2.2.1,>=1.0.0
@@ -99,7 +99,7 @@ xfail_strict = True
 [edgetest.envs.core]
 python_version = 3.9
 deps = 
-	dask
+	dask[dataframe]
 	jupyterlab
 	kaleido
 	lightgbm
@@ -119,7 +119,7 @@ upgrade =
 	dash
 	dash-bootstrap-components
 	fsspec
-	intake[dataframe]
+	intake
 	jsonpath-ng
 	numpy
 	pandas

--- a/tests/unit/client/test_rubicon_client.py
+++ b/tests/unit/client/test_rubicon_client.py
@@ -227,7 +227,7 @@ def test_get_project_as_dask_df(rubicon_and_project_client_with_experiments):
     rubicon, project = rubicon_and_project_client_with_experiments
     ddf = rubicon.get_project_as_df(name="Test Project", df_type="dask")
 
-    assert isinstance(ddf, dd.core.DataFrame)
+    assert isinstance(ddf, dd.DataFrame)
 
 
 def test_get_project_as_pandas_df(rubicon_and_project_client_with_experiments):


### PR DESCRIPTION
## What
  * uses `dask.DataFrame` instead of `dask.core.DataFrame` in the test check
  * moves the dataframe extra from `intake` (doesn't exist anymore) to `dask`

## How to Test
  * `python -m pytest`
