### PR TITLE
Update CODEOWNERS to include rubicon-write-team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @capitalone/rubicon-admin-team
+* @capitalone/rubicon-admin-team @capitalone/rubicon-write-team


### PR DESCRIPTION
This is to allow members of either `rubicon-admin-team` or `rubicon-write-team` to approve PRs.