### PR TITLE
support wildcards in tag queries

### DIFF
--- a/notebooks/logging-examples/tagging.ipynb
+++ b/notebooks/logging-examples/tagging.ipynb
@@ -50,16 +50,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "`experiment_a` ID: 09b2ff25-5152-4e82-9532-c1a09de65409, tags: ['a']\n",
-      "`experiment_b` ID: 932f21ff-e839-437f-a7e8-6c05a1186294, tags: ['b']\n",
-      "`experiment_c` ID: ef64c07f-a7ba-4248-bde2-a4a323a09428, tags: ['a', 'b']\n"
+      "`experiment_a` ID: 2e23d721-b58e-44b3-b53a-7889319425ea, tags: ['tag_a']\n",
+      "`experiment_b` ID: 1f573c46-8e82-4fa4-a560-6bd92778b882, tags: ['tag_b']\n",
+      "`experiment_c` ID: 85580996-fa26-49c4-b4ec-fb015c1f517c, tags: ['tag_a', 'tag_b']\n"
      ]
     }
    ],
    "source": [
-    "experiment_a = project.log_experiment(tags=[\"a\"])\n",
-    "experiment_b = project.log_experiment(tags=[\"b\"])\n",
-    "experiment_c = project.log_experiment(tags=[\"a\", \"b\"])\n",
+    "experiment_a = project.log_experiment(tags=[\"tag_a\"])\n",
+    "experiment_b = project.log_experiment(tags=[\"tag_b\"])\n",
+    "experiment_c = project.log_experiment(tags=[\"tag_a\", \"tag_b\"])\n",
     "\n",
     "print(f\"`experiment_a` ID: {experiment_a.id}, tags: {experiment_a.tags}\")\n",
     "print(f\"`experiment_b` ID: {experiment_b.id}, tags: {experiment_b.tags}\")\n",
@@ -84,14 +84,14 @@
     "import pandas as pd\n",
     "\n",
     "artifact = experiment_a.log_artifact(\n",
-    "    data_bytes=b\"artifact\", name=\"artifact\", tags=[\"c\"]\n",
+    "    data_bytes=b\"artifact\", name=\"artifact\", tags=[\"tag_c\"]\n",
     ")\n",
     "dataframe = experiment_a.log_dataframe(\n",
-    "    df=pd.DataFrame([[0], [1]]), tags=[\"d\"]\n",
+    "    df=pd.DataFrame([[0], [1]]), tags=[\"tag_d\"]\n",
     ")\n",
-    "feature = experiment_a.log_feature(name=\"var_0\", tags=[\"e\"])\n",
-    "parameter = experiment_a.log_parameter(name=\"input\", value=0, tags=[\"f\"])\n",
-    "metric = experiment_a.log_metric(name=\"output\", value=1, tags=[\"g\"])"
+    "feature = experiment_a.log_feature(name=\"var_0\", tags=[\"tag_e\"])\n",
+    "parameter = experiment_a.log_parameter(name=\"input\", value=0, tags=[\"tag_f\"])\n",
+    "metric = experiment_a.log_metric(name=\"output\", value=1, tags=[\"tag_g\"])"
    ]
   },
   {
@@ -116,8 +116,8 @@
     {
      "data": {
       "text/plain": [
-       "['09b2ff25-5152-4e82-9532-c1a09de65409',\n",
-       " 'ef64c07f-a7ba-4248-bde2-a4a323a09428']"
+       "['2e23d721-b58e-44b3-b53a-7889319425ea',\n",
+       " '85580996-fa26-49c4-b4ec-fb015c1f517c']"
       ]
      },
      "execution_count": 4,
@@ -126,7 +126,7 @@
     }
    ],
    "source": [
-    "[e.id for e in project.experiments(tags=[\"a\"])]"
+    "[e.id for e in project.experiments(tags=[\"tag_a\"])]"
    ]
   },
   {
@@ -147,8 +147,8 @@
     {
      "data": {
       "text/plain": [
-       "['932f21ff-e839-437f-a7e8-6c05a1186294',\n",
-       " 'ef64c07f-a7ba-4248-bde2-a4a323a09428']"
+       "['1f573c46-8e82-4fa4-a560-6bd92778b882',\n",
+       " '85580996-fa26-49c4-b4ec-fb015c1f517c']"
       ]
      },
      "execution_count": 5,
@@ -157,7 +157,7 @@
     }
    ],
    "source": [
-    "[e.id for e in project.experiments(tags=[\"b\"])]"
+    "[e.id for e in project.experiments(tags=[\"tag_b\"])]"
    ]
   },
   {
@@ -177,9 +177,9 @@
     {
      "data": {
       "text/plain": [
-       "['09b2ff25-5152-4e82-9532-c1a09de65409',\n",
-       " '932f21ff-e839-437f-a7e8-6c05a1186294',\n",
-       " 'ef64c07f-a7ba-4248-bde2-a4a323a09428']"
+       "['2e23d721-b58e-44b3-b53a-7889319425ea',\n",
+       " '1f573c46-8e82-4fa4-a560-6bd92778b882',\n",
+       " '85580996-fa26-49c4-b4ec-fb015c1f517c']"
       ]
      },
      "execution_count": 6,
@@ -188,7 +188,7 @@
     }
    ],
    "source": [
-    "[e.id for e in project.experiments(tags=[\"a\", \"b\"])]"
+    "[e.id for e in project.experiments(tags=[\"tag_a\", \"tag_b\"])]"
    ]
   },
   {
@@ -208,7 +208,7 @@
     {
      "data": {
       "text/plain": [
-       "['ef64c07f-a7ba-4248-bde2-a4a323a09428']"
+       "['85580996-fa26-49c4-b4ec-fb015c1f517c']"
       ]
      },
      "execution_count": 7,
@@ -217,7 +217,71 @@
     }
    ],
    "source": [
-    "[e.id for e in project.experiments(tags=[\"a\", \"b\"], qtype=\"and\")]"
+    "[e.id for e in project.experiments(tags=[\"tag_a\", \"tag_b\"], qtype=\"and\")]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6099dacf-51f1-4f08-98e1-a62d6e19d7f9",
+   "metadata": {},
+   "source": [
+    "### Wildcards\n",
+    "\n",
+    "Retrieval by tags also supports wildcards (``*``) while querying."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8a3ee1b5-0340-481a-8d9e-151caff8e7f8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[\"2e23d721-b58e-44b3-b53a-7889319425ea: ['tag_a']\",\n",
+       " \"85580996-fa26-49c4-b4ec-fb015c1f517c: ['tag_a', 'tag_b']\"]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[f\"{e.id}: {e.tags}\" for e in project.experiments(tags=[\"*_a\"])]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5339a13-f08e-4680-be9b-0bb2bf68607c",
+   "metadata": {},
+   "source": [
+    "Multiple wildcards can be used in a single query. A single wildcard character will match any number of\n",
+    "characters in the tag."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "bb81395a-1b9a-48f9-887f-67f549813226",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[\"2e23d721-b58e-44b3-b53a-7889319425ea: ['tag_a']\",\n",
+       " \"1f573c46-8e82-4fa4-a560-6bd92778b882: ['tag_b']\",\n",
+       " \"85580996-fa26-49c4-b4ec-fb015c1f517c: ['tag_a', 'tag_b']\"]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[f\"{e.id}: {e.tags}\" for e in project.experiments(tags=[\"*_*\"])]"
    ]
   },
   {
@@ -232,17 +296,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "1fd16d81-e94c-408e-9275-623a35f48af8",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['a', 'b']"
+       "['tag_a', 'tag_b']"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -262,23 +326,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "b8c55a1d-9955-4bc2-9384-117b3444a968",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['i', 'h', 'a', 'b']"
+       "['tag_i', 'tag_h', 'tag_a', 'tag_b']"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "experiment_c.add_tags([\"h\", \"i\"])\n",
+    "experiment_c.add_tags([\"tag_h\", \"tag_i\"])\n",
     "experiment_c.tags"
    ]
   },
@@ -292,23 +356,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "4fe6eba0-d58e-4bb9-81ed-886bfc611506",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['i', 'h']"
+       "['tag_i', 'tag_h']"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "experiment_c.remove_tags([\"a\", \"b\"])\n",
+    "experiment_c.remove_tags([\"tag_a\", \"tag_b\"])\n",
     "experiment_c.tags"
    ]
   },
@@ -322,7 +386,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "a9be6033-775c-4d11-b9d6-55364474eb87",
    "metadata": {},
    "outputs": [
@@ -332,13 +396,13 @@
        "[]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "[e.id for e in project.experiments(tags=[\"a\", \"b\"], qtype=\"and\")]"
+    "[e.id for e in project.experiments(tags=[\"tag_a\", \"tag_b\"], qtype=\"and\")]"
    ]
   },
   {
@@ -353,13 +417,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "d68b29d3-436b-476b-9cc3-cf8d4c7e14ac",
    "metadata": {},
    "outputs": [],
    "source": [
-    "experiment_d = project.log_experiment(tags=[\"j:k\"])\n",
-    "experiment_e = project.log_experiment(tags=[\"l:m\", \"l:n\"])"
+    "experiment_d = project.log_experiment(tags=[\"tag_j:k\"])\n",
+    "experiment_e = project.log_experiment(tags=[\"tag_l:m\", \"tag_l:n\"])"
    ]
   },
   {
@@ -373,17 +437,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "3b9ff6f5-b90b-4870-8ffc-0ffe74a8c0f8",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'j:k'"
+       "'tag_j:k'"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -403,7 +467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "622925d8-26fd-4961-b7d5-0625544d736c",
    "metadata": {},
    "outputs": [
@@ -413,13 +477,13 @@
        "'k'"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "experiment_d.tags[\"j\"]"
+    "experiment_d.tags[\"tag_j\"]"
    ]
   },
   {
@@ -432,7 +496,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "07328cb3-9947-4fe9-8359-244530016a7e",
    "metadata": {},
    "outputs": [
@@ -442,13 +506,13 @@
        "['m', 'n']"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "experiment_e.tags[\"l\"]"
+    "experiment_e.tags[\"tag_l\"]"
    ]
   },
   {
@@ -464,19 +528,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "ab2c5a29-b8ee-45e7-b4b9-6dc22c3abdd7",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['a',\n",
-       " 'child:f080134a-b118-4ac4-b400-25fc097366a8',\n",
-       " 'child:9443daa7-0bee-4af8-8f31-79a85017bcd5']"
+       "['child:a0260c5a-a0e5-4a90-8667-514795a9c329',\n",
+       " 'child:8dc5ecb3-368f-42ea-b444-b49d997045a3',\n",
+       " 'tag_a']"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -493,23 +557,25 @@
    "id": "7c3367cc-77f3-4c20-b7ab-5029e64b8452",
    "metadata": {},
    "source": [
-    "The experiment IDs themselves can be retrieved by indexing into the tags with the \"child\" key."
+    "Now let's say we've only been given `experiment_a` and we don't know anything about its children or how they were logged.\n",
+    "\n",
+    "The child experiment IDs themselves can be retrieved by indexing into the tags with the \"child\" key."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "id": "b3c04d92-6f52-4c19-ab0e-6907b4f8ab17",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['f080134a-b118-4ac4-b400-25fc097366a8',\n",
-       " '9443daa7-0bee-4af8-8f31-79a85017bcd5']"
+       "['a0260c5a-a0e5-4a90-8667-514795a9c329',\n",
+       " '8dc5ecb3-368f-42ea-b444-b49d997045a3']"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -523,23 +589,23 @@
    "id": "5aae42a9-2ebd-4444-98ff-0127f3ed737c",
    "metadata": {},
    "source": [
-    "From there, we can use the IDs grab the entire experiments from the original project."
+    "From there, we can use the IDs grab the complete child experiments from the original project."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "id": "876a3358-2277-47b4-910f-1a1db89bda9d",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<rubicon_ml.client.experiment.Experiment at 0x1744780d0>,\n",
-       " <rubicon_ml.client.experiment.Experiment at 0x1744781f0>]"
+       "[<rubicon_ml.client.experiment.Experiment at 0x11927c130>,\n",
+       " <rubicon_ml.client.experiment.Experiment at 0x11927c430>]"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/notebooks/logging-examples/tagging.ipynb
+++ b/notebooks/logging-examples/tagging.ipynb
@@ -50,15 +50,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "`experiment_a` ID: 2e23d721-b58e-44b3-b53a-7889319425ea, tags: ['tag_a']\n",
-      "`experiment_b` ID: 1f573c46-8e82-4fa4-a560-6bd92778b882, tags: ['tag_b']\n",
-      "`experiment_c` ID: 85580996-fa26-49c4-b4ec-fb015c1f517c, tags: ['tag_a', 'tag_b']\n"
+      "`experiment_a` ID: 7e08c0bf-7f88-46d1-89de-4e0da7e2a448, tags: ['tag_a']\n",
+      "`experiment_b` ID: 75e54061-5910-43a0-a036-c5a6bdd77ca1, tags: ['other_tag_a', 'tag_b']\n",
+      "`experiment_c` ID: cc09ea5c-18df-48b1-888e-e692f5d9e71a, tags: ['tag_a', 'tag_b']\n"
      ]
     }
    ],
    "source": [
     "experiment_a = project.log_experiment(tags=[\"tag_a\"])\n",
-    "experiment_b = project.log_experiment(tags=[\"tag_b\"])\n",
+    "experiment_b = project.log_experiment(tags=[\"other_tag_a\", \"tag_b\"])\n",
     "experiment_c = project.log_experiment(tags=[\"tag_a\", \"tag_b\"])\n",
     "\n",
     "print(f\"`experiment_a` ID: {experiment_a.id}, tags: {experiment_a.tags}\")\n",
@@ -116,8 +116,8 @@
     {
      "data": {
       "text/plain": [
-       "['2e23d721-b58e-44b3-b53a-7889319425ea',\n",
-       " '85580996-fa26-49c4-b4ec-fb015c1f517c']"
+       "[\"7e08c0bf-7f88-46d1-89de-4e0da7e2a448: ['tag_a']\",\n",
+       " \"cc09ea5c-18df-48b1-888e-e692f5d9e71a: ['tag_a', 'tag_b']\"]"
       ]
      },
      "execution_count": 4,
@@ -126,7 +126,7 @@
     }
    ],
    "source": [
-    "[e.id for e in project.experiments(tags=[\"tag_a\"])]"
+    "[f\"{e.id}: {e.tags}\" for e in project.experiments(tags=[\"tag_a\"])]"
    ]
   },
   {
@@ -147,8 +147,8 @@
     {
      "data": {
       "text/plain": [
-       "['1f573c46-8e82-4fa4-a560-6bd92778b882',\n",
-       " '85580996-fa26-49c4-b4ec-fb015c1f517c']"
+       "[\"75e54061-5910-43a0-a036-c5a6bdd77ca1: ['other_tag_a', 'tag_b']\",\n",
+       " \"cc09ea5c-18df-48b1-888e-e692f5d9e71a: ['tag_a', 'tag_b']\"]"
       ]
      },
      "execution_count": 5,
@@ -157,7 +157,7 @@
     }
    ],
    "source": [
-    "[e.id for e in project.experiments(tags=[\"tag_b\"])]"
+    "[f\"{e.id}: {e.tags}\" for e in project.experiments(tags=[\"tag_b\"])]"
    ]
   },
   {
@@ -177,9 +177,9 @@
     {
      "data": {
       "text/plain": [
-       "['2e23d721-b58e-44b3-b53a-7889319425ea',\n",
-       " '1f573c46-8e82-4fa4-a560-6bd92778b882',\n",
-       " '85580996-fa26-49c4-b4ec-fb015c1f517c']"
+       "[\"7e08c0bf-7f88-46d1-89de-4e0da7e2a448: ['tag_a']\",\n",
+       " \"75e54061-5910-43a0-a036-c5a6bdd77ca1: ['other_tag_a', 'tag_b']\",\n",
+       " \"cc09ea5c-18df-48b1-888e-e692f5d9e71a: ['tag_a', 'tag_b']\"]"
       ]
      },
      "execution_count": 6,
@@ -188,7 +188,7 @@
     }
    ],
    "source": [
-    "[e.id for e in project.experiments(tags=[\"tag_a\", \"tag_b\"])]"
+    "[f\"{e.id}: {e.tags}\" for e in project.experiments(tags=[\"tag_a\", \"tag_b\"])]"
    ]
   },
   {
@@ -208,7 +208,7 @@
     {
      "data": {
       "text/plain": [
-       "['85580996-fa26-49c4-b4ec-fb015c1f517c']"
+       "[\"cc09ea5c-18df-48b1-888e-e692f5d9e71a: ['tag_a', 'tag_b']\"]"
       ]
      },
      "execution_count": 7,
@@ -217,7 +217,7 @@
     }
    ],
    "source": [
-    "[e.id for e in project.experiments(tags=[\"tag_a\", \"tag_b\"], qtype=\"and\")]"
+    "[f\"{e.id}: {e.tags}\" for e in project.experiments(tags=[\"tag_a\", \"tag_b\"], qtype=\"and\")]"
    ]
   },
   {
@@ -239,8 +239,9 @@
     {
      "data": {
       "text/plain": [
-       "[\"2e23d721-b58e-44b3-b53a-7889319425ea: ['tag_a']\",\n",
-       " \"85580996-fa26-49c4-b4ec-fb015c1f517c: ['tag_a', 'tag_b']\"]"
+       "[\"7e08c0bf-7f88-46d1-89de-4e0da7e2a448: ['tag_a']\",\n",
+       " \"75e54061-5910-43a0-a036-c5a6bdd77ca1: ['other_tag_a', 'tag_b']\",\n",
+       " \"cc09ea5c-18df-48b1-888e-e692f5d9e71a: ['tag_a', 'tag_b']\"]"
       ]
      },
      "execution_count": 8,
@@ -270,9 +271,7 @@
     {
      "data": {
       "text/plain": [
-       "[\"2e23d721-b58e-44b3-b53a-7889319425ea: ['tag_a']\",\n",
-       " \"1f573c46-8e82-4fa4-a560-6bd92778b882: ['tag_b']\",\n",
-       " \"85580996-fa26-49c4-b4ec-fb015c1f517c: ['tag_a', 'tag_b']\"]"
+       "[\"75e54061-5910-43a0-a036-c5a6bdd77ca1: ['other_tag_a', 'tag_b']\"]"
       ]
      },
      "execution_count": 9,
@@ -281,7 +280,7 @@
     }
    ],
    "source": [
-    "[f\"{e.id}: {e.tags}\" for e in project.experiments(tags=[\"*_*\"])]"
+    "[f\"{e.id}: {e.tags}\" for e in project.experiments(tags=[\"*_*_*\"])]"
    ]
   },
   {
@@ -333,7 +332,7 @@
     {
      "data": {
       "text/plain": [
-       "['tag_i', 'tag_h', 'tag_a', 'tag_b']"
+       "['tag_i', 'tag_h', 'tag_b', 'tag_a']"
       ]
      },
      "execution_count": 11,
@@ -402,7 +401,7 @@
     }
    ],
    "source": [
-    "[e.id for e in project.experiments(tags=[\"tag_a\", \"tag_b\"], qtype=\"and\")]"
+    "[f\"{e.id}: {e.tags}\" for e in project.experiments(tags=[\"tag_a\", \"tag_b\"], qtype=\"and\")]"
    ]
   },
   {
@@ -423,7 +422,7 @@
    "outputs": [],
    "source": [
     "experiment_d = project.log_experiment(tags=[\"tag_j:k\"])\n",
-    "experiment_e = project.log_experiment(tags=[\"tag_l:m\", \"tag_l:n\"])"
+    "experiment_e = project.log_experiment(tags=[\"tag_j:l\", \"tag_m:n\", \"tag_m:o\"])"
    ]
   },
   {
@@ -503,7 +502,7 @@
     {
      "data": {
       "text/plain": [
-       "['m', 'n']"
+       "['n', 'o']"
       ]
      },
      "execution_count": 17,
@@ -512,7 +511,37 @@
     }
    ],
    "source": [
-    "experiment_e.tags[\"tag_l\"]"
+    "experiment_e.tags[\"tag_m\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a85a3307-eb62-4bd1-b0eb-9367f6edf164",
+   "metadata": {},
+   "source": [
+    "Combine key-value tags and wildcards to examine the value of _\"tag_j\"_ on every experiment that has one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "334e5096-b816-4981-b6c2-6e741a323a3e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['0962a69f-1db5-4f42-884c-60ad179bdb5c: k',\n",
+       " 'd5c9d775-e546-4b02-93ac-f5cee6d17aea: l']"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[f\"{e.id}: {e.tags['tag_j']}\" for e in project.experiments(tags=[\"tag_j:*\"])]"
    ]
   },
   {
@@ -528,19 +557,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "ab2c5a29-b8ee-45e7-b4b9-6dc22c3abdd7",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['child:a0260c5a-a0e5-4a90-8667-514795a9c329',\n",
-       " 'child:8dc5ecb3-368f-42ea-b444-b49d997045a3',\n",
+       "['child:0962a69f-1db5-4f42-884c-60ad179bdb5c',\n",
+       " 'child:d5c9d775-e546-4b02-93ac-f5cee6d17aea',\n",
        " 'tag_a']"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -564,18 +593,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "b3c04d92-6f52-4c19-ab0e-6907b4f8ab17",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['a0260c5a-a0e5-4a90-8667-514795a9c329',\n",
-       " '8dc5ecb3-368f-42ea-b444-b49d997045a3']"
+       "['0962a69f-1db5-4f42-884c-60ad179bdb5c',\n",
+       " 'd5c9d775-e546-4b02-93ac-f5cee6d17aea']"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -594,18 +623,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "876a3358-2277-47b4-910f-1a1db89bda9d",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<rubicon_ml.client.experiment.Experiment at 0x11927c130>,\n",
-       " <rubicon_ml.client.experiment.Experiment at 0x11927c430>]"
+       "[<rubicon_ml.client.experiment.Experiment at 0x163cad2a0>,\n",
+       " <rubicon_ml.client.experiment.Experiment at 0x163cad030>]"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/rubicon_ml/client/utils/tags.py
+++ b/rubicon_ml/client/utils/tags.py
@@ -32,17 +32,9 @@ def has_tag_requirements(tags: List[str], required_tags: List[str], qtype: str) 
     """Returns True if `tags` meets the requirements based on
     the values of `required_tags` and `qtype`. False otherwise.
     """
-    has_tag_requirements = False
+    qtype_func = any if qtype == "or" else all
 
-    tag_intersection = set(required_tags).intersection(set(tags))
-    if qtype == "or":
-        if len(tag_intersection) > 0:
-            has_tag_requirements = True
-    if qtype == "and":
-        if len(tag_intersection) == len(required_tags):
-            has_tag_requirements = True
-
-    return has_tag_requirements
+    return qtype_func(tag in tags for tag in required_tags)
 
 
 def filter_children(children, tags, qtype, name):

--- a/tests/unit/client/utils/test_tags.py
+++ b/tests/unit/client/utils/test_tags.py
@@ -3,32 +3,45 @@ import pytest
 from rubicon_ml.client.utils.tags import TagContainer, has_tag_requirements
 
 
-def test_or_single_success():
-    assert has_tag_requirements(["x", "y", "z"], ["y"], "or")
+@pytest.mark.parametrize(
+    ["required_tags", "qtype"],
+    [
+        (["pre_y_post"], "or"),
+        (["missing", "pre_y_post"], "or"),
+        (["pre_y_post"], "and"),
+        (["pre_y_post", "pre_z"], "and"),
+        (["x_post", "pre_y_post"], "and"),
+        (["*y*"], "or"),
+        (["missing", "*y*"], "or"),
+        (["*y*"], "and"),
+        (["*y*", "*z"], "and"),
+        (["x*", "*y*"], "and"),
+        (["*_*_*", "*_*"], "and"),
+    ],
+)
+def test_has_tags(required_tags, qtype):
+    tags = ["x_post", "pre_y_post", "pre_z"]
+
+    assert has_tag_requirements(tags, required_tags, qtype)
 
 
-def test_or_multiple_success():
-    assert has_tag_requirements(["x", "y", "z"], ["a", "y"], "or")
+@pytest.mark.parametrize(
+    ["required_tags", "qtype"],
+    [
+        (["missing"], "or"),
+        (["missing"], "and"),
+        (["missing", "pre_z"], "and"),
+        (["*y"], "or"),
+        (["y*"], "or"),
+        (["*y"], "and"),
+        (["y*"], "and"),
+        (["missing", "*z"], "and"),
+    ],
+)
+def test_not_has_tags(required_tags, qtype):
+    tags = ["x_post", "pre_y_post", "pre_z"]
 
-
-def test_or_single_failure():
-    assert not has_tag_requirements(["x", "y", "z"], ["a"], "or")
-
-
-def test_and_single_success():
-    assert has_tag_requirements(["x", "y", "z"], ["y"], "and")
-
-
-def test_and_multiple_success():
-    assert has_tag_requirements(["x", "y", "z"], ["y", "z"], "and")
-
-
-def test_and_single_failure():
-    assert not has_tag_requirements(["x", "y", "z"], ["a"], "and")
-
-
-def test_and_multiple_failure():
-    assert not has_tag_requirements(["x", "y", "z"], ["a", "z"], "and")
+    assert not has_tag_requirements(tags, required_tags, qtype)
 
 
 def test_tag_container():


### PR DESCRIPTION
## What
  * updates `has_tag_requirements` to handle wildcards (`*`) in tag queries
    * a single wildcard character will match any number of characters
    * multiple wildcards can be used in a single query

## How to Test
  * run "notebooks/logging-examples/tagging.ipynb"
  * `python -m pytest tests/unit/client/utils/test_tags.py`
