### PR TITLE
Add visualization widgets to catalog through publish.py

### DIFF
--- a/rubicon_ml/intake_rubicon/publish.py
+++ b/rubicon_ml/intake_rubicon/publish.py
@@ -1,9 +1,16 @@
+from typing import TYPE_CHECKING, Optional
+
 import fsspec
 import yaml
+
+if TYPE_CHECKING:
+    from rubicon_ml.viz.experiments_table import ExperimentsTable
 
 
 def publish(
     experiments,
+    # visualization object passed, defaulted to None
+    visualization_object: Optional["ExperimentsTable"] = None,
     output_filepath=None,
     base_catalog_filepath=None,
 ):
@@ -35,10 +42,12 @@ def publish(
         return _update_catalog(
             base_catalog_filepath=base_catalog_filepath,
             new_experiments=experiments,
+            # pass to update catalog
+            new_visualization=visualization_object,
             output_filepath=output_filepath,
         )
-
-    catalog = _build_catalog(experiments=experiments)
+    # if new file then just pass viz object straight to build catalog
+    catalog = _build_catalog(experiments=experiments, visualization=visualization_object)
     catalog_yaml = yaml.dump(catalog)
 
     if output_filepath is not None:
@@ -48,7 +57,9 @@ def publish(
     return catalog_yaml
 
 
-def _update_catalog(base_catalog_filepath, new_experiments, output_filepath=None):
+def _update_catalog(
+    base_catalog_filepath, new_experiments, new_visualization, output_filepath=None
+):
     """Helper function to update exisiting intake catalog.
 
     Parameters
@@ -73,8 +84,8 @@ def _update_catalog(base_catalog_filepath, new_experiments, output_filepath=None
     dict
         The dictionary of all sources given as experiments to eventually publish
     """
-
-    updated_catalog = _build_catalog(experiments=new_experiments)
+    # rebuild a temp catalog with new visualization
+    updated_catalog = _build_catalog(experiments=new_experiments, visualization=new_visualization)
 
     with fsspec.open(base_catalog_filepath, "r") as yamlfile:
         curr_catalog = yaml.safe_load(yamlfile)
@@ -90,7 +101,7 @@ def _update_catalog(base_catalog_filepath, new_experiments, output_filepath=None
     return updated_catalog
 
 
-def _build_catalog(experiments):
+def _build_catalog(experiments, visualization):
     """Helper function to build catalog dictionary from given experiments.
 
     Parameters
@@ -118,5 +129,23 @@ def _build_catalog(experiments):
 
         experiment_catalog_name = f"experiment_{experiment.id.replace('-', '_')}"
         catalog["sources"][experiment_catalog_name] = appended_experiment_catalog
+
+    # create visualization entry to the catalog file
+    if visualization is not None:
+        appended_visualization_catalog = {
+            "driver": "rubicon_ml_experiment_table",
+            "args": {
+                "is_selectable": visualization.is_selectable,
+                "metric_names": visualization.metric_names,
+                "metric_query_tags": visualization.metric_query_tags,
+                "metric_query_type": visualization.metric_query_type,
+                "parameter_names": visualization.parameter_names,
+                "parameter_query_tags": visualization.parameter_query_tags,
+                "parameter_query_type": visualization.parameter_query_type,
+            },
+        }
+
+        # append visualization object to end of catalog file
+        catalog["sources"]["experiment_table"] = appended_visualization_catalog
 
     return catalog


### PR DESCRIPTION
**Description**
Issue: Currently we are trying to build an extension for serving visualizations through a Juptyer lab extension. To do this we want to include visualization information in the catalogs. 

Solution: For this issue, rubicon_ml.publish.py now optionally takes in a single viz object (ExperimentTable only at the moment) and publishs it as an entry in the output catalog. The arguments for the entry are all the arguments that are input into the viz object itself so it can be recreated later. 


**Changes**
1) The publish() function now takes in a visualization object which is defaulted to None, added type hinting using mypy (only for ExperimentsTable object)
2) Added type checking for the ExperimentsTable type such that it only gets imported during type checking.
3) Incorporated a new visualization functionality to update_catalog() such that it will build a new catalog with the new visualization object if there is one passed, otherwise just the experiments. 
4) Updated build_catalog() such that a new visualization entry is appended to the catalog file in yaml format with the parameters inputted into the visualization object. 


**Related Issues**
[#444](https://github.com/capitalone/rubicon-ml/issues/444) -> Original Issue discussing changes needed and background
[#449 ](https://github.com/capitalone/rubicon-ml/pull/449) -> Original Pull request with initial feedback on 1st commit for changes 


