### PR TITLE
Created an Intake Source for Experiment Table

### DIFF
--- a/rubicon_ml/intake_rubicon/__init__.py
+++ b/rubicon_ml/intake_rubicon/__init__.py
@@ -1,5 +1,6 @@
 import intake  # noqa F401
 
 from rubicon_ml.intake_rubicon.experiment import ExperimentSource
+from rubicon_ml.intake_rubicon.viz import ExperimentsTableDataSource
 
-__all__ = ["ExperimentSource"]
+__all__ = ["ExperimentSource", "ExperimentsTableDataSource"]

--- a/rubicon_ml/intake_rubicon/viz.py
+++ b/rubicon_ml/intake_rubicon/viz.py
@@ -1,0 +1,22 @@
+from rubicon_ml import __version__
+from rubicon_ml.intake_rubicon.base import VizDataSourceMixin
+from rubicon_ml.viz import ExperimentsTable
+
+
+class ExperimentsTableDataSource(VizDataSourceMixin):
+    """An Intake data source for reading `rubicon` Experiment Table visualizations."""
+
+    version = __version__
+
+    container = "python"
+    name = "rubicon_ml_experiments_table"
+
+    def __init__(self, metadata=None, **catalog_data):
+        self._catalog_data = catalog_data or {}
+
+        super().__init__(metadata=metadata)
+
+    def _get_schema(self):
+        """Creates an Experiments Table visualization and sets it as the visualization object attribute"""
+        self._visualization_object = ExperimentsTable(**self._catalog_data)
+        return super()._get_schema()

--- a/rubicon_ml/viz/experiments_table.py
+++ b/rubicon_ml/viz/experiments_table.py
@@ -4,7 +4,7 @@ import dash_bootstrap_components as dbc
 from dash import dash_table, dcc, html
 from dash.dependencies import ALL, Input, Output, State
 
-from rubicon_ml import publish
+from rubicon_ml.intake_rubicon.publish import publish
 from rubicon_ml.viz.base import VizBase
 from rubicon_ml.viz.common.colors import light_blue, plot_background_blue
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ console_scripts =
 	rubicon_ml = rubicon_ml.cli:cli
 intake.drivers = 
 	rubicon_ml_experiment = rubicon_ml.intake_rubicon.experiment:ExperimentSource
+ 	rubicon_ml_experiment_table = rubicon_ml.intake_rubicon.viz:ExperimentsTableDataSource
 
 [versioneer]
 vcs = git

--- a/tests/unit/intake_rubicon/test_publish.py
+++ b/tests/unit/intake_rubicon/test_publish.py
@@ -1,17 +1,14 @@
-from typing import TYPE_CHECKING, Optional
-
 import fsspec
 import yaml
 
 from rubicon_ml import Rubicon, publish
-
-if TYPE_CHECKING:
-    from rubicon_ml.viz.experiments_table import ExperimentsTable
+from rubicon_ml.viz.experiments_table import ExperimentsTable
 
 
-def test_publish(project_client, visualization_object: Optional["ExperimentsTable"] = None):
+def test_publish(project_client):
     project = project_client
     experiment = project.log_experiment()
+    visualization_object = ExperimentsTable()
     catalog_yaml = publish(project.experiments(), visualization_object)
     catalog = yaml.safe_load(catalog_yaml)
 
@@ -36,6 +33,7 @@ def test_publish(project_client, visualization_object: Optional["ExperimentsTabl
             "project_name"
         ]
     )
+    assert catalog["sources"]["experiment_table"] is not None
 
 
 def test_publish_from_multiple_sources():

--- a/tests/unit/intake_rubicon/test_viz.py
+++ b/tests/unit/intake_rubicon/test_viz.py
@@ -1,0 +1,35 @@
+import os
+
+from rubicon_ml.intake_rubicon.viz import ExperimentsTableDataSource
+
+root = os.path.dirname(__file__)
+
+
+def test_experiments_table_source():
+    catalog_data_sample = {
+        "is_selectable": True,
+        "metric_names": None,
+        "metric_query_tags": None,
+        "metric_query_type": None,
+        "parameter_names": None,
+        "parameter_query_tags": None,
+        "parameter_query_type": None,
+    }
+
+    source = ExperimentsTableDataSource(catalog_data_sample)
+    assert source is not None
+
+    source.discover()
+
+    visualization = source.read()
+
+    assert visualization is not None
+    assert visualization.is_selectable == catalog_data_sample["is_selectable"]
+    assert visualization.metric_names == catalog_data_sample["metric_names"]
+    assert visualization.metric_query_tags == catalog_data_sample["metric_query_tags"]
+    assert visualization.metric_query_type == catalog_data_sample["metric_query_type"]
+    assert visualization.parameter_names == catalog_data_sample["parameter_names"]
+    assert visualization.parameter_query_tags == catalog_data_sample["parameter_query_tags"]
+    assert visualization.parameter_query_type == catalog_data_sample["parameter_query_type"]
+
+    source.close()


### PR DESCRIPTION
**Description**
Issue: Currently we are trying to build an extension for serving visualizations through a Juptyer lab extension. To do this we want to include visualization information in the catalogs. Initially, we created a base visualization data source similar to the existing one for projects and experiments. Now we need to create a concrete implementation for Experiments Table. 
[base.py](https://github.com/capitalone/rubicon-ml/blob/main/rubicon_ml/intake_rubicon/base.py)


Solution: For this issue, we added a new ExperimentsTableDataSource that is going to extend VizDataSourceMixin. We will read in the catalog data and metadata from the passed arguments . Then `_get_schema` creates a experiments Table visualization and sets it as the visualization object attribute. 

**Changes**

1) Created a new file called `viz.py` within the intake_rubicon folder. This file holds the code for the new `ExperimentsTableDataSource`. 
2) Updated the `__init__ ` function within the intake_rubicon folder to now be able to include ExperimentsTableDataSource for module importing purposes. 
3) Updated   `rubicon_ml/viz/experiments_table.py` to import the publish function straight from the intake_rubicon folder as there was a circular import issue. 
4) Updated the `setup.cfg` file to include the ExperimentsTableDataSource as an Intake driver. 

**Related Issues**
[#442](https://github.com/capitalone/rubicon-ml/issues/442) -> Original Issue discussing changes needed and background
[#441](https://github.com/capitalone/rubicon-ml/issues/441) -> An extension of this issue. 
