### PR TITLE
Work to deprecate pickle flag

### DIFF
--- a/rubicon_ml/client/artifact.py
+++ b/rubicon_ml/client/artifact.py
@@ -51,7 +51,7 @@ class Artifact(Base, TagMixin, CommentMixin):
     def _get_data(self):
         """Loads the data associated with this artifact."""
         project_name, experiment_id = self.parent._get_identifiers()
-        return_err = RuntimeError("Data was not loaded properly.")
+        return_err = None
 
         self._data = None
 
@@ -91,9 +91,7 @@ class Artifact(Base, TagMixin, CommentMixin):
             **Deprecated**: Please use `deserialize="pickle"` in the future.
         """
         project_name, experiment_id = self.parent._get_identifiers()
-        return_err = RuntimeError(
-            f"Valid deseralization methods are 'h2o' and 'pickle', found {deserialize}"
-        )
+        return_err = None
 
         if unpickle:
             warnings.warn(

--- a/rubicon_ml/client/artifact.py
+++ b/rubicon_ml/client/artifact.py
@@ -51,7 +51,7 @@ class Artifact(Base, TagMixin, CommentMixin):
     def _get_data(self):
         """Loads the data associated with this artifact."""
         project_name, experiment_id = self.parent._get_identifiers()
-        return_err = None
+        return_err = RuntimeError("Data was not loaded properly.")
 
         self._data = None
 
@@ -71,7 +71,7 @@ class Artifact(Base, TagMixin, CommentMixin):
     @failsafe
     def get_data(
         self,
-        deserialize: Optional[Literal["h2o"]] = None,
+        deserialize: Optional[Literal["h2o", "pickle"]] = None,
         unpickle: bool = False,  # TODO: deprecate & move to `deserialize`
     ):
         """Loads the data associated with this artifact and
@@ -83,13 +83,24 @@ class Artifact(Base, TagMixin, CommentMixin):
             Method to use to deseralize this artifact's data.
             * None to disable deseralization and return the raw data.
             * "h2o" to use `h2o.load_model` to load the data.
+            * "pickle" to use pickles to load the data.
             Defaults to None.
         unpickle : bool, optional
             Flag indicating whether or not to unpickle artifact data.
             `deserialize` takes precedence. Defaults to False.
+            **Deprecated**: Please use `deserialize="pickle"` in the future.
         """
         project_name, experiment_id = self.parent._get_identifiers()
-        return_err = None
+        return_err = RuntimeError(
+            f"Valid deseralization methods are 'h2o' and 'pickle', found {deserialize}"
+        )
+
+        if unpickle:
+            warnings.warn(
+                "`unpickle` is deprecated, please use `deserialize='pickle'` instead",
+                DeprecationWarning,
+            )
+            deserialize = "pickle"
 
         for repo in self.repositories or []:
             try:
@@ -103,7 +114,7 @@ class Artifact(Base, TagMixin, CommentMixin):
                     data = h2o.load_model(
                         repo._get_artifact_data_path(project_name, experiment_id, self.id)
                     )
-                elif unpickle:
+                elif deserialize == "pickle":
                     data = pickle.loads(data)
 
                 return data

--- a/tests/unit/client/test_artifact_client.py
+++ b/tests/unit/client/test_artifact_client.py
@@ -88,7 +88,25 @@ def test_get_data_unpickle_true(project_client):
     test_object = TestObject()
     artifact = project.log_artifact(name="test object", data_object=test_object)
 
-    assert artifact.get_data(unpickle=True).value == test_object.value
+    with pytest.deprecated_call():
+        assert artifact.get_data(unpickle=True).value == test_object.value
+
+
+def test_get_data_deserialize_with_pickle(project_client):
+    """deserialize="pickle" intended for retrieving python objects
+    that were logged as artifacts, hence dummy object is needed.
+    """
+
+    project = project_client
+    global TestObject  # cannot pickle local variable
+
+    class TestObject:
+        value = 1
+
+    test_object = TestObject()
+    artifact = project.log_artifact(name="test object", data_object=test_object)
+
+    assert artifact.get_data(deserialize="pickle").value == test_object.value
 
 
 def test_get_data_multiple_backend_error():


### PR DESCRIPTION
Starts work toward: #458 
---

## What
  * Moves the pickle loading functionality into the `deserialize` string. This is the first step of adding functionality for other model types. 
  * Followups include: xgboost support, ONNX support.

## How to Test
  * Run new and existing unit tests.
