### PR TITLE
allow additional AWS CLI config via `sync`

### DIFF
--- a/rubicon_ml/client/rubicon.py
+++ b/rubicon_ml/client/rubicon.py
@@ -299,7 +299,13 @@ class Rubicon:
             raise return_err
 
     @failsafe
-    def sync(self, project_name, s3_root_dir, aws_profile=None, aws_shared_credentials_file=None):
+    def sync(
+        self,
+        project_name: str,
+        s3_root_dir: str,
+        aws_profile: Optional[str] = None,
+        aws_shared_credentials_file: Optional[str] = None,
+    ):
         """Sync a local project to S3.
 
         Parameters

--- a/tests/unit/client/test_rubicon_client.py
+++ b/tests/unit/client/test_rubicon_client.py
@@ -232,7 +232,7 @@ def test_sync_aws_inputs(mock_get_project, mock_run, default_cred_path):
     )
 
     assert (
-        "aws s3 sync --profile my-profile " "./local/path/sync-test-project s3://test/path"
+        "aws s3 sync --profile my-profile ./local/path/sync-test-project s3://test/path"
     ) in str(mock_run._mock_call_args_list)
 
     if default_cred_path:

--- a/tests/unit/client/test_rubicon_client.py
+++ b/tests/unit/client/test_rubicon_client.py
@@ -219,7 +219,14 @@ def test_sync(mock_get_project, mock_run):
 def test_sync_aws_inputs(mock_get_project, mock_run, default_cred_path):
     rubicon = Rubicon(persistence="filesystem", root_dir="./local/path")
     project_name = "Sync Test Project"
-    mock_get_project.return_value = client.Project(domain.Project(project_name))
+    cred_path = "./my-creds"
+
+    def __get_project_check_cred_path(*args):
+        assert os.environ["AWS_SHARED_CREDENTIALS_FILE"] == cred_path
+
+        return client.Project(domain.Project(project_name))
+
+    mock_get_project.side_effect = __get_project_check_cred_path
 
     if default_cred_path:
         os.environ["AWS_SHARED_CREDENTIALS_FILE"] = default_cred_path
@@ -228,7 +235,7 @@ def test_sync_aws_inputs(mock_get_project, mock_run, default_cred_path):
         project_name,
         "s3://test/path",
         aws_profile="my-profile",
-        aws_shared_credentials_file="./my-creds",
+        aws_shared_credentials_file=cred_path,
     )
 
     assert (


### PR DESCRIPTION
## What
  * allows users to directly specify a AWS profile and credential location for the sync operation

## How to Test
  * `python -m pytest tests/unit/client/test_rubicon_client.py -k test_sync`
