### PR TITLE
guard viz import and fix prefect dependency

### DIFF
--- a/docs/docs-environment.yml
+++ b/docs/docs-environment.yml
@@ -28,6 +28,3 @@ dependencies:
   - pyarrow<=16.1.0,>=14.0.1
   - PyYAML<=6.0.1,>=5.4.0
   - scikit-learn<=1.5.0,>=0.22.0
-
-  - pip:
-    - backports.strenum<=1.3.1,>=1.3.1;python_version!=3.11

--- a/docs/docs-environment.yml
+++ b/docs/docs-environment.yml
@@ -17,7 +17,7 @@ dependencies:
 
   # install rubicon-ml dependencies
   # so local pip install doesn't
-  - backports.strenum<=1.3.1,>=1.3.1
+  - backports.strenum<=1.3.1,>=1.3.1;python_version!=3.11
   - dash<=2.17.1,>=2.11.0
   - dash-bootstrap-components<=1.6.0,>=1.0.0
   - fsspec<=2024.6.1,>=2021.4.0

--- a/docs/docs-environment.yml
+++ b/docs/docs-environment.yml
@@ -17,6 +17,7 @@ dependencies:
 
   # install rubicon-ml dependencies
   # so local pip install doesn't
+  - backports.strenum<=1.3.1,>=1.3.1
   - dash<=2.17.1,>=2.11.0
   - dash-bootstrap-components<=1.6.0,>=1.0.0
   - fsspec<=2024.6.1,>=2021.4.0

--- a/docs/docs-environment.yml
+++ b/docs/docs-environment.yml
@@ -17,7 +17,6 @@ dependencies:
 
   # install rubicon-ml dependencies
   # so local pip install doesn't
-  - backports.strenum<=1.3.1,>=1.3.1;python_version!=3.11
   - dash<=2.17.1,>=2.11.0
   - dash-bootstrap-components<=1.6.0,>=1.0.0
   - fsspec<=2024.6.1,>=2021.4.0
@@ -29,3 +28,6 @@ dependencies:
   - pyarrow<=16.1.0,>=14.0.1
   - PyYAML<=6.0.1,>=5.4.0
   - scikit-learn<=1.5.0,>=0.22.0
+
+  - pip:
+    - backports.strenum<=1.3.1,>=1.3.1;python_version!=3.11

--- a/docs/docs-environment.yml
+++ b/docs/docs-environment.yml
@@ -24,7 +24,7 @@ dependencies:
   - jsonpath-ng<=1.6.1,>=1.5.3
   - numpy<=2.0.0,>=1.22.0
   - pandas<=2.2.2,>=1.0.0
-  - prefect<=2.19.7,>=2.16.5
+  - prefect<=2.19.8,>=2.16.5
   - pyarrow<=16.1.0,>=14.0.1
   - PyYAML<=6.0.1,>=5.4.0
   - scikit-learn<=1.5.0,>=0.22.0

--- a/docs/docs-environment.yml
+++ b/docs/docs-environment.yml
@@ -28,3 +28,7 @@ dependencies:
   - pyarrow<=16.1.0,>=14.0.1
   - PyYAML<=6.0.1,>=5.4.0
   - scikit-learn<=1.5.0,>=0.22.0
+
+  - pip:
+    # additional prefect extras
+    - backports.strenum<=1.3.1,>=1.3.1;python_version<'3.11'

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - scikit-learn<=1.5.0,>=0.22.0
 
   # for prefect extras
-  - prefect<=2.19.7,>=2.16.5
+  - prefect<=2.19.8,>=2.16.5
 
   # for s3fs extras
   - s3fs<=2024.6.1,>=0.4

--- a/environment.yml
+++ b/environment.yml
@@ -51,6 +51,3 @@ dependencies:
   # for edgetest
   - edgetest
   - edgetest-conda
-
-  - pip:
-    - backports.strenum<=1.3.1,>=1.3.1;python_version!=3.11

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - scikit-learn<=1.5.0,>=0.22.0
 
   # for prefect extras
+  - backports.strenum<=1.3.1,>=1.3.1
   - prefect<=2.19.8,>=2.16.5
 
   # for s3fs extras

--- a/environment.yml
+++ b/environment.yml
@@ -51,3 +51,7 @@ dependencies:
   # for edgetest
   - edgetest
   - edgetest-conda
+
+  - pip:
+    # additional prefect extras
+    - backports.strenum<=1.3.1,>=1.3.1;python_version<'3.11'

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - scikit-learn<=1.5.0,>=0.22.0
 
   # for prefect extras
-  - backports.strenum<=1.3.1,>=1.3.1
+  - backports.strenum<=1.3.1,>=1.3.1;python_version!=3.11
   - prefect<=2.19.8,>=2.16.5
 
   # for s3fs extras

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,6 @@ dependencies:
   - scikit-learn<=1.5.0,>=0.22.0
 
   # for prefect extras
-  - backports.strenum<=1.3.1,>=1.3.1;python_version!=3.11
   - prefect<=2.19.8,>=2.16.5
 
   # for s3fs extras
@@ -52,3 +51,6 @@ dependencies:
   # for edgetest
   - edgetest
   - edgetest-conda
+
+  - pip:
+    - backports.strenum<=1.3.1,>=1.3.1;python_version!=3.11

--- a/rubicon_ml/intake_rubicon/viz.py
+++ b/rubicon_ml/intake_rubicon/viz.py
@@ -1,6 +1,5 @@
 from rubicon_ml import __version__
 from rubicon_ml.intake_rubicon.base import VizDataSourceMixin
-from rubicon_ml.viz import ExperimentsTable
 
 
 class ExperimentsTableDataSource(VizDataSourceMixin):
@@ -18,5 +17,8 @@ class ExperimentsTableDataSource(VizDataSourceMixin):
 
     def _get_schema(self):
         """Creates an Experiments Table visualization and sets it as the visualization object attribute"""
+        from rubicon_ml.viz import ExperimentsTable
+
         self._visualization_object = ExperimentsTable(**self._catalog_data)
+
         return super()._get_schema()

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
 
 [options.extras_require]
 prefect = 
-	backports.strenum<=1.3.1,>=1.3.1;python_version!=3.11
+	backports.strenum<=1.3.1,>=1.3.1;python_version<'3.11'
 	prefect<=2.19.8,>=2.16.5
 s3 = 
 	s3fs<=2024.6.1,>=0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
 
 [options.extras_require]
 prefect = 
-	backports.strenum<=1.3.1,>=1.3.1
+	backports.strenum<=1.3.1,>=1.3.1;python_version!=3.11
 	prefect<=2.19.8,>=2.16.5
 s3 = 
 	s3fs<=2024.6.1,>=0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
 
 [options.extras_require]
 prefect = 
+	backports.strenum<=1.3.1,>=1.3.1
 	prefect<=2.19.8,>=2.16.5
 s3 = 
 	s3fs<=2024.6.1,>=0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
 
 [options.extras_require]
 prefect = 
-	prefect<=2.19.7,>=2.16.5
+	prefect<=2.19.8,>=2.16.5
 s3 = 
 	s3fs<=2024.6.1,>=0.4
 ui = 


### PR DESCRIPTION
## What
  * guards the `ExperimentsTable` import in `viz.py` so a simple `import rubicon_ml` does not require additional dependencies
  * fixes `prefect` import - dependency `backports.strenum` no longer included with `prefect` for some reason
    * installs it via `pip` in conda envs as I can't figure out how to get them to respect the python version qualifier

## How to Test
  * `pip install rubicon-ml` in a new environment
  * `import rubicon_ml` and validate there are no errors
