### PR TITLE
Fixed metric lists comparison length None bug

### DIFF
--- a/rubicon_ml/viz/metric_lists_comparison.py
+++ b/rubicon_ml/viz/metric_lists_comparison.py
@@ -38,7 +38,10 @@ class MetricListsComparison(VizBase):
     ):
         super().__init__(dash_title="compare metric lists")
 
-        self.column_names = column_names
+        if column_names == None:
+            self.column_names = []
+        else:
+            self.column_names = column_names
         self.experiments = experiments
         self.selected_metric = selected_metric
 

--- a/rubicon_ml/viz/metric_lists_comparison.py
+++ b/rubicon_ml/viz/metric_lists_comparison.py
@@ -38,7 +38,7 @@ class MetricListsComparison(VizBase):
     ):
         super().__init__(dash_title="compare metric lists")
 
-        if column_names == None:
+        if column_names is None:
             self.column_names = []
         else:
             self.column_names = column_names

--- a/tests/unit/intake_rubicon/test_viz.py
+++ b/tests/unit/intake_rubicon/test_viz.py
@@ -107,7 +107,7 @@ def test_metric_list_source():
     visualization = source.read()
 
     assert visualization is not None
-    assert visualization.column_names == catalog_data_sample["column_names"]
+    assert visualization.column_names == []
     assert visualization.selected_metric == catalog_data_sample["selected_metric"]
 
     source.close()

--- a/tests/unit/viz/test_metric_lists_comparison.py
+++ b/tests/unit/viz/test_metric_lists_comparison.py
@@ -4,9 +4,10 @@ from dash import Dash
 from rubicon_ml.viz import MetricListsComparison
 
 
-def test_metric_lists_comparison(viz_experiments):
+@pytest.mark.parametrize("column_names", [["var_0", "var_1", "var_2", "var_3", "var_4"], None])
+def test_metric_lists_comparison(viz_experiments, column_names):
     metric_comparison = MetricListsComparison(
-        column_names=["var_0", "var_1", "var_2", "var_3", "var_4"],
+        column_names=column_names,
         experiments=viz_experiments,
         selected_metric="test metric 2",
     )
@@ -19,7 +20,10 @@ def test_metric_lists_comparison(viz_experiments):
         expected_experiment_ids.remove(experiment.id)
 
     assert len(expected_experiment_ids) == 0
-    assert metric_comparison.column_names == ["var_0", "var_1", "var_2", "var_3", "var_4"]
+    if column_names is not None:
+        assert metric_comparison.column_names == ["var_0", "var_1", "var_2", "var_3", "var_4"]
+    else:
+        assert metric_comparison.column_names == []
     assert metric_comparison.selected_metric == "test metric 2"
 
 

--- a/tests/unit/viz/test_metric_lists_comparison.py
+++ b/tests/unit/viz/test_metric_lists_comparison.py
@@ -20,10 +20,10 @@ def test_metric_lists_comparison(viz_experiments, column_names):
         expected_experiment_ids.remove(experiment.id)
 
     assert len(expected_experiment_ids) == 0
-    if column_names is not None:
-        assert metric_comparison.column_names == ["var_0", "var_1", "var_2", "var_3", "var_4"]
-    else:
+    if column_names is None:
         assert metric_comparison.column_names == []
+    else:
+        assert metric_comparison.column_names == ["var_0", "var_1", "var_2", "var_3", "var_4"]
     assert metric_comparison.selected_metric == "test metric 2"
 
 


### PR DESCRIPTION
closes: #470 

---

## What
  * when MetricListsComparison.column_names is the default None, there is a check against its len that raises an error
## How to Test
  * Modified a test, test_metric_lists_comparison to test length depending on input
