### PR TITLE
experiment dataclass - warn on extra kwargs

### DIFF
--- a/rubicon_ml/domain/experiment.py
+++ b/rubicon_ml/domain/experiment.py
@@ -1,24 +1,86 @@
-from __future__ import annotations
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List, Optional
 
-from dataclasses import dataclass, field
-from datetime import datetime
-from typing import List, Optional
+from rubicon_ml.domain.mixin import CommentMixin, InitMixin, TagMixin
 
-from rubicon_ml.domain.mixin import CommentMixin, TagMixin
-from rubicon_ml.domain.utils import TrainingMetadata, uuid
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from rubicon_ml.domain.utils import TrainingMetadata
 
 
-@dataclass
-class Experiment(TagMixin, CommentMixin):
+@dataclass(init=False)
+class Experiment(CommentMixin, InitMixin, TagMixin):
+    """A domain-level experiment.
+
+    project_name : str
+        The name of the project the experiment belongs to.
+    branch_name : str, optional
+        The name of the git branch associated with the experiment.
+    comments : list of str, optional
+        Additional text information and observations about the experiment.
+    commit_hash : str, optional
+        The hash of the git commit associated with the experiment.
+    created_at : datetime, optional
+        The date and time the experiment was created. Defaults to `None` and uses
+        `datetime.datetime.now` to generate a UTC timestamp. `created_at` should be
+        left as `None` to allow for automatic generation.
+    description : str, optional
+        A description of the experiment. Defaults to `None`.
+    id : str, optional
+        The experiment's unique identifier. Defaults to `None` and uses `uuid.uuid4`
+        to generate a unique ID. `id` should be left as `None` to allow for automatic
+        generation.
+    model_name : str, optional
+        The name of the model associated with the experiment.
+    name : str, optional
+        The experiment's name.
+    tags : list of str, optional
+        The values this experiment is tagged with.
+    training_metadata : rubicon_ml.domain.utils.TrainingMetadata, optional
+        Additional metadata pertaining to any data this experiment was trained on.
+        Defaults to `None`.
+    """
+
     project_name: str
-
-    id: str = field(default_factory=uuid.uuid4)
-    name: Optional[str] = None
-    description: Optional[str] = None
-    model_name: Optional[str] = None
     branch_name: Optional[str] = None
+    comments: List[str] = None
     commit_hash: Optional[str] = None
-    training_metadata: Optional[TrainingMetadata] = None
-    tags: List[str] = field(default_factory=list)
-    comments: List[str] = field(default_factory=list)
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: Optional["datetime"] = None
+    description: Optional[str] = None
+    id: Optional[str] = None
+    model_name: Optional[str] = None
+    name: Optional[str] = None
+    tags: List[str] = None
+    training_metadata: Optional["TrainingMetadata"] = None
+
+    def __init__(
+        self,
+        project_name: str,
+        branch_name: Optional[str] = None,
+        comments: List[str] = None,
+        commit_hash: Optional[str] = None,
+        created_at: Optional["datetime"] = None,
+        description: Optional[str] = None,
+        id: Optional[str] = None,
+        model_name: Optional[str] = None,
+        name: Optional[str] = None,
+        tags: List[str] = None,
+        training_metadata: Optional["TrainingMetadata"] = None,
+        **kwargs,
+    ):
+        """Initialize this domain experiment."""
+
+        self._check_extra_kwargs(kwargs)
+
+        self.project_name = project_name
+        self.branch_name = branch_name
+        self.comments = comments or []
+        self.commit_hash = commit_hash
+        self.created_at = self._init_created_at(created_at)
+        self.description = description
+        self.id = self._init_id(id)
+        self.model_name = model_name
+        self.name = name
+        self.tags = tags or []
+        self.training_metadata = training_metadata

--- a/rubicon_ml/domain/experiment.py
+++ b/rubicon_ml/domain/experiment.py
@@ -16,11 +16,12 @@ class Experiment(CommentMixin, InitMixin, TagMixin):
     project_name : str
         The name of the project the experiment belongs to.
     branch_name : str, optional
-        The name of the git branch associated with the experiment.
+        The name of the git branch associated with the experiment. Defaults to `None`.
     comments : list of str, optional
-        Additional text information and observations about the experiment.
+        Additional text information and observations about the experiment. Defaults to
+        `None`.
     commit_hash : str, optional
-        The hash of the git commit associated with the experiment.
+        The hash of the git commit associated with the experiment. Defaults to `None`.
     created_at : datetime, optional
         The date and time the experiment was created. Defaults to `None` and uses
         `datetime.datetime.now` to generate a UTC timestamp. `created_at` should be
@@ -32,11 +33,11 @@ class Experiment(CommentMixin, InitMixin, TagMixin):
         to generate a unique ID. `id` should be left as `None` to allow for automatic
         generation.
     model_name : str, optional
-        The name of the model associated with the experiment.
+        The name of the model associated with the experiment. Defaults to `None`.
     name : str, optional
-        The experiment's name.
+        The experiment's name. Defaults to `None`.
     tags : list of str, optional
-        The values this experiment is tagged with.
+        The values this experiment is tagged with. Defaults to `None`.
     training_metadata : rubicon_ml.domain.utils.TrainingMetadata, optional
         Additional metadata pertaining to any data this experiment was trained on.
         Defaults to `None`.
@@ -44,28 +45,28 @@ class Experiment(CommentMixin, InitMixin, TagMixin):
 
     project_name: str
     branch_name: Optional[str] = None
-    comments: List[str] = None
+    comments: Optional[List[str]] = None
     commit_hash: Optional[str] = None
     created_at: Optional["datetime"] = None
     description: Optional[str] = None
     id: Optional[str] = None
     model_name: Optional[str] = None
     name: Optional[str] = None
-    tags: List[str] = None
+    tags: Optional[List[str]] = None
     training_metadata: Optional["TrainingMetadata"] = None
 
     def __init__(
         self,
         project_name: str,
         branch_name: Optional[str] = None,
-        comments: List[str] = None,
+        comments: Optional[List[str]] = None,
         commit_hash: Optional[str] = None,
         created_at: Optional["datetime"] = None,
         description: Optional[str] = None,
         id: Optional[str] = None,
         model_name: Optional[str] = None,
         name: Optional[str] = None,
-        tags: List[str] = None,
+        tags: Optional[List[str]] = None,
         training_metadata: Optional["TrainingMetadata"] = None,
         **kwargs,
     ):

--- a/rubicon_ml/domain/mixin.py
+++ b/rubicon_ml/domain/mixin.py
@@ -1,30 +1,9 @@
-from typing import List
+import datetime
+import logging
+import uuid
+from typing import Dict, List, Optional
 
-
-class TagMixin:
-    """Adds tagging support to a domain model."""
-
-    def add_tags(self, tags: List[str]):
-        """
-        Add new tags to this model.
-
-        Parameters
-        ----------
-        tags : List[str]
-            A list of string tags to add to the domain model.
-        """
-        self.tags = list(set(self.tags).union(set(tags)))
-
-    def remove_tags(self, tags: List[str]):
-        """
-        Remove tags from this model.
-
-        Parameters
-        ----------
-        tags : List[str]
-            A list of string tags to remove from this domain model.
-        """
-        self.tags = list(set(self.tags).difference(set(tags)))
+LOGGER = logging.getLogger()
 
 
 class CommentMixin:
@@ -51,3 +30,64 @@ class CommentMixin:
             A list of string comments to remove from this domain model.
         """
         self.comments = list(set(self.comments).difference(set(comments)))
+
+
+class InitMixin:
+    """Adds helpers for initializing default values."""
+
+    def _check_extra_kwargs(self, kwargs: Dict):
+        """Warn if extra kwargs are given when initialized.
+
+        Replaces default `dataclass` behavior of erroring on unexpected kwargs.
+        """
+        if kwargs:
+            LOGGER.warning(
+                f"{self.__class__.__name__}.__init__() got an unexpected keyword "
+                f"argument(s): `{'`, `'.join([key for key in kwargs])}`"
+            )
+
+    def _init_created_at(self, created_at: Optional[datetime.datetime]) -> datetime.datetime:
+        """Initialize the `created_at` attribute to the current time if necessary.
+
+        `datetime.UTC` was added and `datetime.utcnow` was deprecated in Python 3.11.
+        """
+        if created_at is None:
+            try:
+                return datetime.datetime.now(datetime.UTC)
+            except AttributeError:
+                return datetime.datetime.utcnow()
+
+        return created_at
+
+    def _init_id(self, id: Optional[str]) -> str:
+        """Initialize the `id` attribute to a new UUID if necessary."""
+        if id is None:
+            return str(uuid.uuid4())
+
+        return id
+
+
+class TagMixin:
+    """Adds tagging support to a domain model."""
+
+    def add_tags(self, tags: List[str]):
+        """
+        Add new tags to this model.
+
+        Parameters
+        ----------
+        tags : List[str]
+            A list of string tags to add to the domain model.
+        """
+        self.tags = list(set(self.tags).union(set(tags)))
+
+    def remove_tags(self, tags: List[str]):
+        """
+        Remove tags from this model.
+
+        Parameters
+        ----------
+        tags : List[str]
+            A list of string tags to remove from this domain model.
+        """
+        self.tags = list(set(self.tags).difference(set(tags)))

--- a/rubicon_ml/domain/project.py
+++ b/rubicon_ml/domain/project.py
@@ -1,17 +1,16 @@
-import datetime
-import logging
-import uuid
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
-if TYPE_CHECKING:
-    from rubicon_ml.domain.utils import TrainingMetadata
+from rubicon_ml.domain.mixin import InitMixin
 
-LOGGER = logging.getLogger()
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from rubicon_ml.domain.utils import TrainingMetadata
 
 
 @dataclass(init=False)
-class Project:
+class Project(InitMixin):
     """A domain-level project.
 
     Parameters
@@ -37,8 +36,7 @@ class Project:
     """
 
     name: str
-
-    created_at: Optional[datetime.datetime] = None
+    created_at: Optional["datetime"] = None
     description: Optional[str] = None
     github_url: Optional[str] = None
     id: Optional[str] = None
@@ -47,7 +45,7 @@ class Project:
     def __init__(
         self,
         name: str,
-        created_at: Optional[datetime.datetime] = None,
+        created_at: Optional["datetime"] = None,
         description: Optional[str] = None,
         github_url: Optional[str] = None,
         id: Optional[str] = None,
@@ -56,25 +54,11 @@ class Project:
     ):
         """Initialize this domain project."""
 
-        self.name = name
+        self._check_extra_kwargs(kwargs)
 
-        self.created_at = created_at
+        self.name = name
+        self.created_at = self._init_created_at(created_at)
         self.description = description
         self.github_url = github_url
-        self.id = id
+        self.id = self._init_id(id)
         self.training_metadata = training_metadata
-
-        if self.created_at is None:
-            try:  # `datetime.UTC` added & `datetime.utcnow` deprecated in Python 3.11
-                self.created_at = datetime.datetime.now(datetime.UTC)
-            except AttributeError:
-                self.created_at = datetime.datetime.utcnow()
-
-        if self.id is None:
-            self.id = str(uuid.uuid4())
-
-        if kwargs:  # replaces `dataclass` behavior of erroring on unexpected kwargs
-            LOGGER.warning(
-                f"{self.__class__.__name__}.__init__() got an unexpected keyword "
-                f"argument(s): `{'`, `'.join([key for key in kwargs])}`"
-            )

--- a/tests/unit/domain/test_domain.py
+++ b/tests/unit/domain/test_domain.py
@@ -2,12 +2,15 @@ from unittest import mock
 
 import pytest
 
-from rubicon_ml.domain.project import Project
+from rubicon_ml.domain import Experiment, Project
 
 
 @pytest.mark.parametrize(
     ["domain_cls", "required_kwargs"],
-    [(Project, {"name": "test_domain_extra_kwargs"})],
+    [
+        (Project, {"name": "test_domain_extra_kwargs"}),
+        (Experiment, {"project_name": "test_domain_extra_kwargs"}),
+    ],
 )
 def test_domain_extra_kwargs(domain_cls, required_kwargs):
     with mock.patch("rubicon_ml.domain.mixin.LOGGER.warning") as mock_logger_warning:

--- a/tests/unit/domain/test_domain.py
+++ b/tests/unit/domain/test_domain.py
@@ -10,9 +10,7 @@ from rubicon_ml.domain.project import Project
     [(Project, {"name": "test_domain_extra_kwargs"})],
 )
 def test_domain_extra_kwargs(domain_cls, required_kwargs):
-    with mock.patch(
-        f"rubicon_ml.domain.{domain_cls.__name__.lower()}.LOGGER.warning"
-    ) as mock_logger_warning:
+    with mock.patch("rubicon_ml.domain.mixin.LOGGER.warning") as mock_logger_warning:
         domain = domain_cls(extra="extra", **required_kwargs)
 
     mock_logger_warning.assert_called_once_with(


### PR DESCRIPTION
followup to #474

## What
  * overrides the domain `Experiment`'s `dataclass`-created `__init__`
    * warn on unexpected kwargs rather than error to support forwards and backwards compatibility across changes to the rubicon-ml data model
    * from this point forward, any rubicon-ml library version should be able to read experiments from disk written by any other rubicon-ml library version (assuming only the data model changes, not the way the library itself reads data)
  * moves shared initialization code between `Project` and `Experiment` into `InitMixin`

## How to Test
  * `python -m pytest tests/unit/domain/test_domain.py`

## Next Steps
  * repeat the process for the remaining domain-level `dataclass`es
