### PR TITLE
remaining dataclasses - warn on extra kwargs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,7 @@ exclude_lines =
     raise AssertionError
     raise NotImplementedError
     if __name__ == .__main__.:
+    if TYPE_CHECKING:
 omit =
     versioneer.py
     rubicon_ml/_version.py

--- a/rubicon_ml/domain/artifact.py
+++ b/rubicon_ml/domain/artifact.py
@@ -1,21 +1,65 @@
-from __future__ import annotations
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List, Optional
 
-from dataclasses import dataclass, field
-from datetime import datetime
-from typing import List, Optional
+from rubicon_ml.domain.mixin import CommentMixin, InitMixin, TagMixin
 
-from rubicon_ml.domain.mixin import CommentMixin, TagMixin
-from rubicon_ml.domain.utils import uuid
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
-@dataclass
-class Artifact(TagMixin, CommentMixin):
+@dataclass(init=False)
+class Artifact(CommentMixin, InitMixin, TagMixin):
+    """A domain-level artifact.
+
+    name : str
+        The artifact's name.
+    comments : list of str, optional
+        Additional text information and observations about the artifact. Defaults to
+        `None`.
+    created_at : datetime, optional
+        The date and time the artifact was created. Defaults to `None` and uses
+        `datetime.datetime.now` to generate a UTC timestamp. `created_at` should be
+        left as `None` to allow for automatic generation.
+    description : str, optional
+        A description of the artifact. Defaults to `None`.
+    id : str, optional
+        The artifact's unique identifier. Defaults to `None` and uses `uuid.uuid4`
+        to generate a unique ID. `id` should be left as `None` to allow for automatic
+        generation.
+    parent_id : str, optional
+        The unique identifier of the project or experiment the artifact belongs to.
+        Defaults to `None`.
+    tags : list of str, optional
+        The values this artifact is tagged with. Defaults to `None`.
+    """
+
     name: str
-
-    id: str = field(default_factory=uuid.uuid4)
+    comments: Optional[List[str]] = None
+    created_at: Optional["datetime"] = None
     description: Optional[str] = None
-    created_at: datetime = field(default_factory=datetime.utcnow)
-    tags: List[str] = field(default_factory=list)
-    comments: List[str] = field(default_factory=list)
-
+    id: Optional[str] = None
     parent_id: Optional[str] = None
+    tags: Optional[List[str]] = None
+
+    def __init__(
+        self,
+        name: str,
+        comments: Optional[List[str]] = None,
+        created_at: Optional["datetime"] = None,
+        description: Optional[str] = None,
+        id: Optional[str] = None,
+        parent_id: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        **kwargs,
+    ):
+        """Initialize this domain artifact."""
+
+        self._check_extra_kwargs(kwargs)
+
+        self.name = name
+        self.comments = comments or []
+        self.created_at = self._init_created_at(created_at)
+        self.description = description
+        self.id = self._init_id(id)
+        self.parent_id = parent_id
+        self.tags = tags or []

--- a/rubicon_ml/domain/dataframe.py
+++ b/rubicon_ml/domain/dataframe.py
@@ -1,20 +1,65 @@
-from __future__ import annotations
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List, Optional
 
-from dataclasses import dataclass, field
-from datetime import datetime
-from typing import List, Optional
+from rubicon_ml.domain.mixin import CommentMixin, InitMixin, TagMixin
 
-from rubicon_ml.domain.mixin import CommentMixin, TagMixin
-from rubicon_ml.domain.utils import uuid
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
-@dataclass
-class Dataframe(TagMixin, CommentMixin):
-    id: str = field(default_factory=uuid.uuid4)
-    name: Optional[str] = None
+@dataclass(init=False)
+class Dataframe(CommentMixin, InitMixin, TagMixin):
+    """A domain-level dataframe.
+
+    comments : list of str, optional
+        Additional text information and observations about the dataframe. Defaults to
+        `None`.
+    created_at : datetime, optional
+        The date and time the dataframe was created. Defaults to `None` and uses
+        `datetime.datetime.now` to generate a UTC timestamp. `created_at` should be
+        left as `None` to allow for automatic generation.
+    description : str, optional
+        A description of the dataframe. Defaults to `None`.
+    id : str, optional
+        The dataframe's unique identifier. Defaults to `None` and uses `uuid.uuid4`
+        to generate a unique ID. `id` should be left as `None` to allow for automatic
+        generation.
+    name : str, optional
+        The dataframe's name. Defaults to `None`.
+    parent_id : str, optional
+        The unique identifier of the project or experiment the dataframe belongs to.
+        Defaults to `None`.
+    tags : list of str, optional
+        The values this dataframe is tagged with. Defaults to `None`.
+    """
+
+    comments: Optional[List[str]] = None
+    created_at: Optional["datetime"] = None
     description: Optional[str] = None
-    tags: List[str] = field(default_factory=list)
-    comments: List[str] = field(default_factory=list)
-    created_at: datetime = field(default_factory=datetime.utcnow)
-
+    id: Optional[str] = None
+    name: Optional[str] = None
     parent_id: Optional[str] = None
+    tags: Optional[List[str]] = None
+
+    def __init__(
+        self,
+        comments: Optional[List[str]] = None,
+        created_at: Optional["datetime"] = None,
+        description: Optional[str] = None,
+        id: Optional[str] = None,
+        name: Optional[str] = None,
+        parent_id: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        **kwargs,
+    ):
+        """Initialize this doimain dataframe."""
+
+        self._check_extra_kwargs(kwargs)
+
+        self.comments = comments or []
+        self.created_at = self._init_created_at(created_at)
+        self.description = description
+        self.id = self._init_id(id)
+        self.name = name
+        self.parent_id = parent_id
+        self.tags = tags or []

--- a/rubicon_ml/domain/feature.py
+++ b/rubicon_ml/domain/feature.py
@@ -1,18 +1,64 @@
-from dataclasses import dataclass, field
-from datetime import datetime
-from typing import List, Optional
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List, Optional
 
-from rubicon_ml.domain.mixin import CommentMixin, TagMixin
-from rubicon_ml.domain.utils import uuid
+from rubicon_ml.domain.mixin import CommentMixin, InitMixin, TagMixin
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
-@dataclass
-class Feature(TagMixin, CommentMixin):
+@dataclass(init=False)
+class Feature(TagMixin, InitMixin, CommentMixin):
+    """A domain-level feature.
+
+    name : str
+        The feature's name.
+    comments : list of str, optional
+        Additional text information and observations about the feature. Defaults to
+        `None`.
+    created_at : datetime, optional
+        The date and time the feature was created. Defaults to `None` and uses
+        `datetime.datetime.now` to generate a UTC timestamp. `created_at` should be
+        left as `None` to allow for automatic generation.
+    description : str, optional
+        A description of the feature. Defaults to `None`.
+    id : str, optional
+        The feature's unique identifier. Defaults to `None` and uses `uuid.uuid4`
+        to generate a unique ID. `id` should be left as `None` to allow for automatic
+        generation.
+    importance : float, optional
+        The feature's calculated importance value. Defaults to `None`.
+    tags : list of str, optional
+        The values this feature is tagged with. Defaults to `None`.
+    """
+
     name: str
-
-    id: str = field(default_factory=uuid.uuid4)
+    comments: Optional[List[str]] = None
+    created_at: Optional["datetime"] = None
     description: Optional[str] = None
+    id: Optional[str] = None
     importance: Optional[float] = None
-    tags: List[str] = field(default_factory=list)
-    comments: List[str] = field(default_factory=list)
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    tags: Optional[List[str]] = None
+
+    def __init__(
+        self,
+        name: str,
+        comments: Optional[List[str]] = None,
+        created_at: Optional["datetime"] = None,
+        description: Optional[str] = None,
+        id: Optional[str] = None,
+        importance: Optional[float] = None,
+        tags: Optional[List[str]] = None,
+        **kwargs,
+    ):
+        """Initialize this domain feature."""
+
+        self._check_extra_kwargs(kwargs)
+
+        self.name = name
+        self.comments = comments or []
+        self.created_at = self._init_created_at(created_at)
+        self.description = description
+        self.id = self._init_id(id)
+        self.importance = importance
+        self.tags = tags or []

--- a/rubicon_ml/domain/feature.py
+++ b/rubicon_ml/domain/feature.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 
 @dataclass(init=False)
-class Feature(TagMixin, InitMixin, CommentMixin):
+class Feature(CommentMixin, InitMixin, TagMixin):
     """A domain-level feature.
 
     name : str

--- a/rubicon_ml/domain/metric.py
+++ b/rubicon_ml/domain/metric.py
@@ -10,7 +10,7 @@ DIRECTIONALITY_VALUES = ["score", "loss"]
 
 
 @dataclass(init=False)
-class Metric(TagMixin, InitMixin, CommentMixin):
+class Metric(CommentMixin, InitMixin, TagMixin):
     """A domain-level metric.
 
     name : str

--- a/rubicon_ml/domain/metric.py
+++ b/rubicon_ml/domain/metric.py
@@ -1,25 +1,75 @@
-from dataclasses import dataclass, field
-from datetime import datetime
-from typing import List, Optional
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, List, Literal, Optional
 
-from rubicon_ml.domain.mixin import CommentMixin, TagMixin
-from rubicon_ml.domain.utils import uuid
+from rubicon_ml.domain.mixin import CommentMixin, InitMixin, TagMixin
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 DIRECTIONALITY_VALUES = ["score", "loss"]
 
 
-@dataclass
-class Metric(TagMixin, CommentMixin):
+@dataclass(init=False)
+class Metric(TagMixin, InitMixin, CommentMixin):
+    """A domain-level metric.
+
+    name : str
+        The metric's name.
+    value : any
+        The metric's value.
+    comments : list of str, optional
+        Additional text information and observations about the metric. Defaults to
+        `None`.
+    created_at : datetime, optional
+        The date and time the metric was created. Defaults to `None` and uses
+        `datetime.datetime.now` to generate a UTC timestamp. `created_at` should be
+        left as `None` to allow for automatic generation.
+    description : str, optional
+        A description of the metric. Defaults to `None`.
+    directionality : "score" or "loss", optional
+        "score" to indicate greater values are better, "loss" to indiciate smaller
+        values are better. Defaults to "score".
+    id : str, optional
+        The metric's unique identifier. Defaults to `None` and uses `uuid.uuid4`
+        to generate a unique ID. `id` should be left as `None` to allow for automatic
+        generation.
+    tags : list of str, optional
+        The values this metric is tagged with. Defaults to `None`.
+    """
+
     name: str
-    value: float
-
-    id: str = field(default_factory=uuid.uuid4)
+    value: Any
+    comments: Optional[List[str]] = None
+    created_at: Optional["datetime"] = None
     description: Optional[str] = None
-    directionality: str = "score"
-    created_at: datetime = field(default_factory=datetime.utcnow)
-    tags: List[str] = field(default_factory=list)
-    comments: List[str] = field(default_factory=list)
+    directionality: Literal["score", "loss"] = "score"
+    id: Optional[str] = None
+    tags: Optional[List[str]] = None
 
-    def __post_init__(self):
-        if self.directionality not in DIRECTIONALITY_VALUES:
-            raise ValueError(f"metric directionality must be one of {DIRECTIONALITY_VALUES}")
+    def __init__(
+        self,
+        name: str,
+        value: Any,
+        comments: Optional[List[str]] = None,
+        created_at: Optional["datetime"] = None,
+        description: Optional[str] = None,
+        directionality: Literal["score", "loss"] = "score",
+        id: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        **kwargs,
+    ):
+        """Initialize this domain metric."""
+
+        if directionality not in DIRECTIONALITY_VALUES:
+            raise ValueError(f"`directionality` must be one of {DIRECTIONALITY_VALUES}")
+
+        self._check_extra_kwargs(kwargs)
+
+        self.name = name
+        self.value = value
+        self.comments = comments or []
+        self.created_at = self._init_created_at(created_at)
+        self.description = description
+        self.directionality = directionality
+        self.id = self._init_id(id)
+        self.tags = tags or []

--- a/rubicon_ml/domain/parameter.py
+++ b/rubicon_ml/domain/parameter.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 
 @dataclass(init=False)
-class Parameter(TagMixin, InitMixin, CommentMixin):
+class Parameter(CommentMixin, InitMixin, TagMixin):
     """A domain-level parameter.
 
     name : str

--- a/rubicon_ml/domain/parameter.py
+++ b/rubicon_ml/domain/parameter.py
@@ -1,18 +1,64 @@
-from dataclasses import dataclass, field
-from datetime import datetime
-from typing import List, Optional
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, List, Optional
 
-from rubicon_ml.domain.mixin import CommentMixin, TagMixin
-from rubicon_ml.domain.utils import uuid
+from rubicon_ml.domain.mixin import CommentMixin, InitMixin, TagMixin
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
-@dataclass
-class Parameter(TagMixin, CommentMixin):
+@dataclass(init=False)
+class Parameter(TagMixin, InitMixin, CommentMixin):
+    """A domain-level parameter.
+
+    name : str
+        The parameter's name.
+    value : any
+        The parameter's value.
+    comments : list of str, optional
+        Additional text information and observations about the parameter. Defaults to
+        `None`.
+    created_at : datetime, optional
+        The date and time the parameter was created. Defaults to `None` and uses
+        `datetime.datetime.now` to generate a UTC timestamp. `created_at` should be
+        left as `None` to allow for automatic generation.
+    description : str, optional
+        A description of the parameter. Defaults to `None`.
+    id : str, optional
+        The parameter's unique identifier. Defaults to `None` and uses `uuid.uuid4`
+        to generate a unique ID. `id` should be left as `None` to allow for automatic
+        generation.
+    tags : list of str, optional
+        The values this parameter is tagged with. Defaults to `None`.
+    """
+
     name: str
-
-    id: str = field(default_factory=uuid.uuid4)
-    value: object = None
+    value: Any
+    comments: Optional[List[str]] = None
+    created_at: Optional["datetime"] = None
     description: Optional[str] = None
-    tags: List[str] = field(default_factory=list)
-    comments: List[str] = field(default_factory=list)
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    id: Optional[str] = None
+    tags: Optional[List[str]] = None
+
+    def __init__(
+        self,
+        name: str,
+        value: Any,
+        comments: Optional[List[str]] = None,
+        created_at: Optional["datetime"] = None,
+        description: Optional[str] = None,
+        id: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        **kwargs,
+    ):
+        """Initialize this domain parameter."""
+
+        self._check_extra_kwargs(kwargs)
+
+        self.name = name
+        self.value = value
+        self.comments = comments or []
+        self.created_at = self._init_created_at(created_at)
+        self.description = description
+        self.id = self._init_id(id)
+        self.tags = tags or []

--- a/rubicon_ml/repository/base.py
+++ b/rubicon_ml/repository/base.py
@@ -11,6 +11,7 @@ import fsspec
 import pandas as pd
 
 from rubicon_ml import domain
+from rubicon_ml.domain.utils.uuid import uuid4
 from rubicon_ml.exceptions import RubiconException
 from rubicon_ml.repository.utils import json, slugify
 
@@ -1140,7 +1141,7 @@ class BaseRepository:
         tag_metadata_root = self._get_tag_metadata_root(
             project_name, experiment_id, entity_identifier, entity_type
         )
-        tag_metadata_path = f"{tag_metadata_root}/tags_{domain.utils.uuid.uuid4()}.json"
+        tag_metadata_path = f"{tag_metadata_root}/tags_{uuid4()}.json"
 
         self._persist_domain({"added_tags": tags}, tag_metadata_path)
 
@@ -1174,7 +1175,7 @@ class BaseRepository:
         tag_metadata_root = self._get_tag_metadata_root(
             project_name, experiment_id, entity_identifier, entity_type
         )
-        tag_metadata_path = f"{tag_metadata_root}/tags_{domain.utils.uuid.uuid4()}.json"
+        tag_metadata_path = f"{tag_metadata_root}/tags_{uuid4()}.json"
 
         self._persist_domain({"removed_tags": tags}, tag_metadata_path)
 
@@ -1274,7 +1275,7 @@ class BaseRepository:
         comment_metadata_root = self._get_comment_metadata_root(
             project_name, experiment_id, entity_identifier, entity_type
         )
-        comment_metadata_path = f"{comment_metadata_root}/comments_{domain.utils.uuid.uuid4()}.json"
+        comment_metadata_path = f"{comment_metadata_root}/comments_{uuid4()}.json"
 
         self._persist_domain({"added_comments": comments}, comment_metadata_path)
 
@@ -1308,7 +1309,7 @@ class BaseRepository:
         comment_metadata_root = self._get_comment_metadata_root(
             project_name, experiment_id, entity_identifier, entity_type
         )
-        comment_metadata_path = f"{comment_metadata_root}/comments_{domain.utils.uuid.uuid4()}.json"
+        comment_metadata_path = f"{comment_metadata_root}/comments_{uuid4()}.json"
 
         self._persist_domain({"removed_comments": comments}, comment_metadata_path)
 

--- a/tests/unit/domain/test_domain.py
+++ b/tests/unit/domain/test_domain.py
@@ -2,12 +2,22 @@ from unittest import mock
 
 import pytest
 
-from rubicon_ml.domain import Experiment, Feature, Metric, Parameter, Project
+from rubicon_ml.domain import (
+    Artifact,
+    Dataframe,
+    Experiment,
+    Feature,
+    Metric,
+    Parameter,
+    Project,
+)
 
 
 @pytest.mark.parametrize(
     ["domain_cls", "required_kwargs"],
     [
+        (Artifact, {"name": "test_domain_extra_kwargs"}),
+        (Dataframe, {}),
         (Experiment, {"project_name": "test_domain_extra_kwargs"}),
         (Feature, {"name": "test_domain_extra_kwargs"}),
         (Metric, {"name": "test_domain_extra_kwargs", "value": 0.0}),

--- a/tests/unit/domain/test_domain.py
+++ b/tests/unit/domain/test_domain.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from rubicon_ml.domain import Experiment, Feature, Project
+from rubicon_ml.domain import Experiment, Feature, Metric, Project
 
 
 @pytest.mark.parametrize(
@@ -10,6 +10,7 @@ from rubicon_ml.domain import Experiment, Feature, Project
     [
         (Experiment, {"project_name": "test_domain_extra_kwargs"}),
         (Feature, {"name": "test_domain_extra_kwargs"}),
+        (Metric, {"name": "test_domain_extra_kwargs", "value": 0.0}),
         (Project, {"name": "test_domain_extra_kwargs"}),
     ],
 )

--- a/tests/unit/domain/test_domain.py
+++ b/tests/unit/domain/test_domain.py
@@ -2,14 +2,15 @@ from unittest import mock
 
 import pytest
 
-from rubicon_ml.domain import Experiment, Project
+from rubicon_ml.domain import Experiment, Feature, Project
 
 
 @pytest.mark.parametrize(
     ["domain_cls", "required_kwargs"],
     [
-        (Project, {"name": "test_domain_extra_kwargs"}),
         (Experiment, {"project_name": "test_domain_extra_kwargs"}),
+        (Feature, {"name": "test_domain_extra_kwargs"}),
+        (Project, {"name": "test_domain_extra_kwargs"}),
     ],
 )
 def test_domain_extra_kwargs(domain_cls, required_kwargs):

--- a/tests/unit/domain/test_domain.py
+++ b/tests/unit/domain/test_domain.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from rubicon_ml.domain import Experiment, Feature, Metric, Project
+from rubicon_ml.domain import Experiment, Feature, Metric, Parameter, Project
 
 
 @pytest.mark.parametrize(
@@ -11,6 +11,7 @@ from rubicon_ml.domain import Experiment, Feature, Metric, Project
         (Experiment, {"project_name": "test_domain_extra_kwargs"}),
         (Feature, {"name": "test_domain_extra_kwargs"}),
         (Metric, {"name": "test_domain_extra_kwargs", "value": 0.0}),
+        (Parameter, {"name": "test_domain_extra_kwargs", "value": 0.0}),
         (Project, {"name": "test_domain_extra_kwargs"}),
     ],
 )


### PR DESCRIPTION
follow up to #474, #475

## What
  * overrides the domain `Artifact`, `Dataframe`, `Feature`, `Metric`, and `Parameter`'s `dataclass`-created `__init__`s
    * warn on unexpected kwargs rather than error to support forwards and backwards compatibility across changes to the rubicon-ml data model
    * from this point forward, any rubicon-ml library version should be able to read domain entities from disk written by any other rubicon-ml library version (assuming only the data model changes, not the way the library itself reads data)

## How to Test
  * `python -m pytest tests/unit/domain/test_domain.py`
