### PR TITLE
add `polars` to edgetest config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -115,6 +115,7 @@ deps =
 	nbformat
 	palmerpenguins
 	Pillow
+        polars
 	pytest
 	pytest-cov
 	prefect


### PR DESCRIPTION
## What
  * fixes the failing edgetest action

## How to Test
  * https://github.com/capitalone/rubicon-ml/actions/runs/10425466514
