### PR TITLE
pass s3 storage options to dataframe read/write

### DIFF
--- a/rubicon_ml/repository/base.py
+++ b/rubicon_ml/repository/base.py
@@ -43,7 +43,7 @@ class BaseRepository:
     """
 
     def __init__(self, root_dir: str, **storage_options):
-        self._df_storage_options = {}
+        self._df_storage_options = {}  # should only be non-empty for S3 logging
 
         self.filesystem = fsspec.filesystem(self.PROTOCOL, **storage_options)
         self.root_dir = root_dir.rstrip("/")

--- a/rubicon_ml/repository/base.py
+++ b/rubicon_ml/repository/base.py
@@ -43,6 +43,8 @@ class BaseRepository:
     """
 
     def __init__(self, root_dir: str, **storage_options):
+        self._df_storage_options = {}
+
         self.filesystem = fsspec.filesystem(self.PROTOCOL, **storage_options)
         self.root_dir = root_dir.rstrip("/")
 
@@ -614,7 +616,7 @@ class BaseRepository:
             df.write_parquet(path)
         else:
             # Dask or pandas
-            df.to_parquet(path, engine="pyarrow")
+            df.to_parquet(path, engine="pyarrow", storage_options=self._df_storage_options)
 
     def _read_dataframe(self, path, df_type: Literal["pandas", "dask", "polars"] = "pandas"):
         """Reads the dataframe `df` from the configured filesystem."""
@@ -623,7 +625,7 @@ class BaseRepository:
 
         if df_type == "pandas":
             path = f"{path}/data.parquet"
-            df = pd.read_parquet(path, engine="pyarrow")
+            df = pd.read_parquet(path, engine="pyarrow", storage_options=self._df_storage_options)
         elif df_type == "polars":
             try:
                 from polars import read_parquet
@@ -633,7 +635,7 @@ class BaseRepository:
                     "to read dataframes with `df_type`='polars'. `pip install polars` "
                     "or `conda install polars` to continue."
                 )
-            df = read_parquet(path)
+            df = read_parquet(path, storage_options=self._df_storage_options)
 
         elif df_type == "dask":
             try:
@@ -645,7 +647,7 @@ class BaseRepository:
                     "or `conda install dask` to continue."
                 )
 
-            df = dd.read_parquet(path, engine="pyarrow")
+            df = dd.read_parquet(path, engine="pyarrow", storage_options=self._df_storage_options)
         else:
             raise ValueError(f"`df_type` must be one of {acceptable_types}")
 

--- a/rubicon_ml/repository/memory.py
+++ b/rubicon_ml/repository/memory.py
@@ -28,6 +28,8 @@ class MemoryRepository(LocalRepository):
     PROTOCOL = "memory"
 
     def __init__(self, root_dir=None, **storage_options):
+        self._df_storage_options = {}
+
         self.filesystem = fsspec.filesystem(self.PROTOCOL, **storage_options)
         self.root_dir = root_dir.rstrip("/") if root_dir is not None else "/root"
 

--- a/rubicon_ml/repository/memory.py
+++ b/rubicon_ml/repository/memory.py
@@ -28,7 +28,7 @@ class MemoryRepository(LocalRepository):
     PROTOCOL = "memory"
 
     def __init__(self, root_dir=None, **storage_options):
-        self._df_storage_options = {}
+        self._df_storage_options = {}  # should only be non-empty for S3 logging
 
         self.filesystem = fsspec.filesystem(self.PROTOCOL, **storage_options)
         self.root_dir = root_dir.rstrip("/") if root_dir is not None else "/root"

--- a/rubicon_ml/repository/s3.py
+++ b/rubicon_ml/repository/s3.py
@@ -1,3 +1,5 @@
+import fsspec
+
 from rubicon_ml.repository import BaseRepository
 from rubicon_ml.repository.utils import json
 
@@ -17,6 +19,12 @@ class S3Repository(BaseRepository):
     """
 
     PROTOCOL = "s3"
+
+    def __init__(self, root_dir: str, **storage_options):
+        self._df_storage_options = storage_options
+
+        self.filesystem = fsspec.filesystem(self.PROTOCOL, **storage_options)
+        self.root_dir = root_dir.rstrip("/")
 
     def _persist_bytes(self, bytes_data, path):
         """Persists the raw bytes `bytes_data` to the S3

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -119,6 +119,7 @@ def rubicon_local_filesystem_client():
     rubicon = Rubicon(
         persistence="filesystem",
         root_dir=os.path.join(os.path.dirname(os.path.realpath(__file__)), "rubicon"),
+        storage_option_a="test",  # should be ignored when logging local dfs
     )
 
     # teardown after yield
@@ -221,7 +222,7 @@ def test_dataframe():
 def memory_repository():
     """Setup an in-memory repository and clean it up afterwards."""
     root_dir = "/in-memory-root"
-    repository = MemoryRepository(root_dir)
+    repository = MemoryRepository(root_dir, storage_option_a="test")
 
     yield repository
     repository.filesystem.rm(root_dir, recursive=True)

--- a/tests/unit/repository/test_base_repo.py
+++ b/tests/unit/repository/test_base_repo.py
@@ -403,7 +403,11 @@ def test_persist_dataframe(mock_to_parquet, memory_repository):
     # calls `BaseRepository._persist_dataframe` despite class using `MemoryRepository`
     super(MemoryRepository, repository)._persist_dataframe(df, path)
 
-    mock_to_parquet.assert_called_once_with(f"{path}/data.parquet", engine="pyarrow")
+    mock_to_parquet.assert_called_once_with(
+        f"{path}/data.parquet",
+        engine="pyarrow",
+        storage_options={},
+    )
 
 
 @patch("polars.DataFrame.write_parquet")
@@ -426,7 +430,11 @@ def test_read_dataframe(mock_read_parquet, memory_repository):
     # calls `BaseRepository._read_dataframe` despite class using `MemoryRepository`
     super(MemoryRepository, repository)._read_dataframe(path)
 
-    mock_read_parquet.assert_called_once_with(f"{path}/data.parquet", engine="pyarrow")
+    mock_read_parquet.assert_called_once_with(
+        f"{path}/data.parquet",
+        engine="pyarrow",
+        storage_options={},
+    )
 
 
 def test_read_dataframe_value_error(memory_repository):


### PR DESCRIPTION
## What
  * `storage_options` were only being passed to `fsspec` for standard file read/write
  * now passes provided storage options to dataframe read/write functions where necessary
    * `storage_options` must be empty for non-remote storage or pandas and dask will error

## How to Test
  * `python -m pytest tests`
