### PR TITLE
remove prefect dependency

### DIFF
--- a/rubicon_ml/workflow/prefect/__init__.py
+++ b/rubicon_ml/workflow/prefect/__init__.py
@@ -5,7 +5,7 @@ def _check_for_prefect_extras():
     try:
         import prefect  # noqa F401
     except ImportError:
-        install_command = "pip install rubicon[prefect]"
+        install_command = "pip install prefect<=2.20.3,>=2.16.5"
         message = f"Install `prefect` with `{install_command}`."
 
         raise ImportError(message)

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,9 +39,6 @@ install_requires =
 	scikit-learn<=1.5.1,>=0.22.0
 
 [options.extras_require]
-prefect = 
-	backports.strenum<=1.3.1,>=1.3.1; python_version < "3.11"
-	prefect<=2.20.3,>=2.16.5
 s3 = 
 	s3fs<=2024.6.1,>=0.4
 ui = 
@@ -53,7 +50,6 @@ viz =
 all = 
 	dash<=2.17.1,>=2.11.0
 	dash-bootstrap-components<=1.6.0,>=1.0.0
-	prefect<=2.20.3,>=2.16.5
 	s3fs<=2024.6.1,>=0.4
 
 [options.entry_points]
@@ -118,7 +114,6 @@ deps =
 	polars
 	pytest
 	pytest-cov
-	prefect
 	xgboost
 extras = 
 	all
@@ -131,7 +126,6 @@ upgrade =
 	jsonpath-ng
 	numpy
 	pandas
-	prefect
 	pyarrow
 	PyYAML
 	s3fs


### PR DESCRIPTION
## What
  * next step in deprecating `workflow` module - followup to #483
  * removes the hard dependency on `prefect`
    * `workflow` module is still usable if `prefect` is installed explicitly

## How to Test
  * `python -m pytest`
