### PR TITLE
update H2O GLM schema

### DIFF
--- a/rubicon_ml/schema/schema/h2o__H2OGeneralizedLinearEstimator.yaml
+++ b/rubicon_ml/schema/schema/h2o__H2OGeneralizedLinearEstimator.yaml
@@ -62,6 +62,7 @@ parameters:
     value_attr: gradient_epsilon
   - name: HGLM
     value_attr: HGLM
+    optional: true
   - name: ignore_const_cols
     value_attr: ignore_const_cols
   - name: ignored_columns


### PR DESCRIPTION
## What
  * marks the removed `HGLM` attributed as optional to handle latest version of H2O

## How to Test
  * validate that the schema tests are passing again
  * validate that the edgetest action passes
    * https://github.com/capitalone/rubicon-ml/actions/runs/11708391135
