### PR TITLE
test: use fixtures, clean up paths & pin dask

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ s3 =
 	s3fs<=2025.3.2,>=0.4
 test = 
 	backports.strenum<=1.3.1,>=1.3.1; python_version < "3.11"
-	dask[dataframe,distributed]
+	dask[dataframe,distributed]<2025.4.0
 	h2o
 	ipykernel
 	jupyterlab

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -78,7 +78,7 @@ def rubicon_client():
     """
     from rubicon_ml import Rubicon
 
-    rubicon = Rubicon(persistence="memory", root_dir="./")
+    rubicon = Rubicon(persistence="memory", root_dir="/")
 
     # teardown after yield
     yield rubicon

--- a/tests/unit/client/test_artifact_client.py
+++ b/tests/unit/client/test_artifact_client.py
@@ -12,7 +12,7 @@ from h2o.estimators.generic import H2OGenericEstimator
 from h2o.estimators.random_forest import H2ORandomForestEstimator
 
 from rubicon_ml import domain
-from rubicon_ml.client import Artifact, Rubicon
+from rubicon_ml.client import Artifact
 from rubicon_ml.exceptions import RubiconException
 
 
@@ -51,17 +51,11 @@ def test_get_json(project_client):
     assert artifact.get_json() == data
 
 
-def test_internal_get_data_multiple_backend_error():
-    rb = Rubicon(
-        composite_config=[
-            {"persistence": "memory", "root_dir": "./memory/rootA"},
-            {"persistence": "memory", "root_dir": "./memory/rootB"},
-        ]
-    )
-    project = rb.create_project("test")
+def test_internal_get_data_multiple_backend_error(rubicon_composite_client):
+    project = rubicon_composite_client.create_project("test")
     data = b"content"
     artifact = project.log_artifact(name="test.txt", data_bytes=data)
-    for repo in rb.repositories:
+    for repo in rubicon_composite_client.repositories:
         repo.delete_artifact(project.name, artifact.id)
     with pytest.raises(RubiconException) as e:
         artifact._get_data()
@@ -111,17 +105,11 @@ def test_get_data_deserialize_with_pickle(project_client):
     assert artifact.get_data(deserialize="pickle").value == test_object.value
 
 
-def test_get_data_multiple_backend_error():
-    rb = Rubicon(
-        composite_config=[
-            {"persistence": "memory", "root_dir": "./memory/rootA"},
-            {"persistence": "memory", "root_dir": "./memory/rootB"},
-        ]
-    )
-    project = rb.create_project("test")
+def test_get_data_multiple_backend_error(rubicon_composite_client):
+    project = rubicon_composite_client.create_project("test")
     data = b"content"
     artifact = project.log_artifact(name="test.txt", data_bytes=data)
-    for repo in rb.repositories:
+    for repo in rubicon_composite_client.repositories:
         repo.delete_artifact(project.name, artifact.id)
     with pytest.raises(RubiconException) as e:
         artifact.get_data()

--- a/tests/unit/client/test_dataframe_client.py
+++ b/tests/unit/client/test_dataframe_client.py
@@ -1,7 +1,7 @@
 import pytest
 
 from rubicon_ml import domain
-from rubicon_ml.client import Dataframe, Rubicon
+from rubicon_ml.client import Dataframe
 from rubicon_ml.exceptions import RubiconException
 
 
@@ -33,17 +33,11 @@ def test_get_data(project_client, test_dataframe):
     assert logged_df.get_data().compute().equals(df.compute())
 
 
-def test_get_data_multiple_backend_error(test_dataframe):
-    rb = Rubicon(
-        composite_config=[
-            {"persistence": "memory", "root_dir": "./memory/rootA"},
-            {"persistence": "memory", "root_dir": "./memory/rootB"},
-        ]
-    )
-    project = rb.create_project("test")
+def test_get_data_multiple_backend_error(rubicon_composite_client, test_dataframe):
+    project = rubicon_composite_client.create_project("test")
     df = test_dataframe
     logged_df = project.log_dataframe(df)
-    for repo in rb.repositories:
+    for repo in rubicon_composite_client.repositories:
         repo.delete_dataframe(project.name, logged_df.id)
     with pytest.raises(RubiconException) as e:
         logged_df.get_data()

--- a/tests/unit/client/test_rubicon_client.py
+++ b/tests/unit/client/test_rubicon_client.py
@@ -43,7 +43,7 @@ def test_set_repository(rubicon_client):
 
 def test_repository_storage_options():
     storage_options = {"key": "secret"}
-    rubicon_memory = Rubicon(persistence="memory", root_dir="./", **storage_options)
+    rubicon_memory = Rubicon(persistence="memory", root_dir="/", **storage_options)
     rubicon_s3 = Rubicon(persistence="filesystem", root_dir="s3://nothing", **storage_options)
 
     assert rubicon_memory.config.repository.filesystem.storage_options["key"] == "secret"
@@ -53,7 +53,7 @@ def test_repository_storage_options():
 def test_multi_repository_storage_options():
     storage_options = {"key": "secret"}
     composite_config = [
-        {"persistence": "memory", "root_dir": "./"},
+        {"persistence": "memory", "root_dir": "/"},
         {"persistence": "filesystem", "root_dir": "s3://nothing"},
     ]
 


### PR DESCRIPTION
## What
  * uses the fixtures with the proper clean up functionality rather than instantiating `Rubicon` objects directly in tests
    * not sure how these tests weren't interfering with each other in their current state
  * remove relative paths from the memory filesystem
    * the memory filesystem has no concept of a relative path since there is no location relative to an irl pwd
  * pins dask to avoid using 2025.4.0 released on Tuesday (4/22/25)
    * causing errors with dask-xgboost: `TypeError: Value type is not supported for data iterator:<class 'distributed.client.Future'>`
    * this error was not introduced in this PR - the last few edgetest runs have been failing as well

## How to Test
  * `python -m pytest`
