### PR TITLE
chore: update `setuptools` & add python 3.12 tests

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -23,11 +23,11 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install -e './[build]'
     - name: Build
       run: |
         python setup.py sdist bdist_wheel

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -30,7 +30,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e './[all,qa,test]'
     - name: Install build dependencies
-      if: ${{ matrix.python-version }} == '3.12'
+      if: ${{ matrix.python-version == '3.12' }}
       run: |
         pip install -e './[build]'
     - name: Check formatting with black
@@ -43,7 +43,7 @@ jobs:
       run: |
         flake8 .
     - name: Validate build
-      if: ${{ matrix.python-version }} == '3.12'
+      if: ${{ matrix.python-version == '3.12' }}
       run: |
         python setup.py sdist bdist_wheel
         pip install dist/rubicon_ml-*.whl

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e './[all,test]'
+        pip install -e './[all,qa,test]'
     - name: Check formatting with black
       run: |
         black --check .

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e "./[dev]"
+        pip install -e './[all,test]'
     - name: Check formatting with black
       run: |
         black --check .

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Validate build
       run: |
         python setup.py sdist bdist_wheel
-        pip install dist/rubicon_ml-*.whl
+        pip install dist/rubicon*ml-*.whl
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -29,6 +29,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e './[all,qa,test]'
+    - name: Install build dependencies
+      if: ${{ matrix.python-version }} == '3.12'
+      run: |
+        pip install -e './[build]'
     - name: Check formatting with black
       run: |
         black --check .
@@ -39,9 +43,10 @@ jobs:
       run: |
         flake8 .
     - name: Validate build
+      if: ${{ matrix.python-version }} == '3.12'
       run: |
         python setup.py sdist bdist_wheel
-        pip install dist/rubicon*ml-*.whl
+        pip install dist/rubicon_ml-*.whl
     - name: Test with pytest
       run: |
         pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
 all = 
 	rubicon-ml[s3,viz]
 dev = 
-	rubicon-ml[docs,qa,s3,test,viz]
+	rubicon-ml[build,docs,qa,s3,test,viz]
 docs = 
 	furo
 	ipython
@@ -52,15 +52,18 @@ docs =
 	rubicon-ml[viz]
 	sphinx
 	sphinx-copybutton
+build =
+	wheel
+	setuptools>=80.3.1
+	twine
 qa = 
 	black
 	edgetest
 	flake8
 	isort
 	pre-commit
-	setuptools
+	rubicon-ml[build]
 	versioneer
-	wheel
 s3 = 
 	s3fs<=2025.3.2,>=0.4
 test = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,10 @@ install_requires =
 [options.extras_require]
 all = 
 	rubicon-ml[s3,viz]
+build =
+	wheel
+	setuptools>=80.3.1
+	twine
 dev = 
 	rubicon-ml[build,docs,qa,s3,test,viz]
 docs = 
@@ -52,17 +56,12 @@ docs =
 	rubicon-ml[viz]
 	sphinx
 	sphinx-copybutton
-build =
-	wheel
-	setuptools>=80.3.1
-	twine
 qa = 
 	black
 	edgetest
 	flake8
 	isort
 	pre-commit
-	rubicon-ml[build]
 	versioneer
 s3 = 
 	s3fs<=2025.3.2,>=0.4


### PR DESCRIPTION
## What

  * updates `setuptools` to use at least the current latest version (80.3.1)
    * the action has been using a version in the mid 60s, triggering deprecation emails from PyPi every time we release
  * adds 3.12 to the test matrix
    * allows use of latest `setuptools`
    * was blocked by prefect stuff removed in #515 
  * only validates build in 3.12 during tests
    * the goal of the build validation step is to ensure the publish workflow will execute properly off main during a release
      * the publish workflow only uses 3.12, so only testing 3.12 should be sufficient

## How to Test

```bash
conda create -n rubicon-ml-build python=3.12
conda activate rubicon-ml-build
pip install -e './[build]'
python setup.py sdist bdist_wheel
pip install dist/*.whl
python -c 'import rubicon_ml; print(rubicon_ml.__version__)'
```

the last command should output something like this: `0.10.5+2.g7269548`
