### PR TITLE
fix: tornado vulnerability

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,2 +1,3 @@
 jupyter-server-proxy
 rubicon-ml[dev]
+tornado>=6.5


### PR DESCRIPTION
closes: #519

---

## What
  * pins `tornado` >= 6.5 to resolve the vulnerability in #519

## How to Test
  * `python -m pytest`
