### PR TITLE
ops: add explicit write permissions to workflows

### DIFF
--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -11,6 +11,9 @@ jobs:
   edgetest:
     runs-on: ubuntu-latest
     name: running edgetest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -14,6 +14,8 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
## What
  * fixes the permissions issue causing edgetest action runs to fail to open PRs against the repo
    * necessary due to org setting changes w/ GHE 

## How to Test
  * validate edgetest and docs workflows
    * edgetest: https://github.com/capitalone/rubicon-ml/actions/runs/16152390242
      * opened PR: https://github.com/capitalone/rubicon-ml/pull/528
    * docs: https://github.com/capitalone/rubicon-ml/actions/runs/16152390242
      * this didn't actually try to push anything since there are no changes - we'll just have to check it out next time we actually push the docs