### PR TITLE
ops: deprecate python 3.8

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.13'
     - name: Install uv
       uses: astral-sh/setup-uv@v6
       with:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.13'
     - name: Install uv
       uses: astral-sh/setup-uv@v6
       with:

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -29,12 +29,12 @@ jobs:
       with:
         version: 'latest'
     - name: Install dependencies
-      if: ${{ matrix.python-version != '3.12' }}
+      if: ${{ matrix.python-version != '3.13' }}
       run: |
         uv venv --python $(which python)
         uv sync --extra all --extra ops --extra test
     - name: Install dependencies with build
-      if: ${{ matrix.python-version == '3.12' }}
+      if: ${{ matrix.python-version == '3.13' }}
       run: |
         uv venv --python $(which python)
         uv sync --extra all --extra build --extra ops --extra test
@@ -47,7 +47,7 @@ jobs:
     - name: Test with pytest
       run: uv run pytest
     - name: Validate build
-      if: ${{ matrix.python-version == '3.12' }}
+      if: ${{ matrix.python-version == '3.13' }}
       run: |
         uv run python -m build
         uv pip install dist/rubicon_ml-*.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "rubicon-ml"
 description = "AI/ML lifecycle metadata logger with configurable backends"
 license = { text = "Apache License, Version 2.0" }
 readme = "README.md"
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 authors = [
     { name = "Ryan Soley" },
     { name = "CapitalOne" }


### PR DESCRIPTION
## What
  * deprecates python 3.8 as it is [EOL](https://devguide.python.org/versions/#unsupported-versions)

## How to Test
  * `uv run pytest`
