### PR TITLE
ops: migrate to `ruff`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,0 @@
-# TODO: USE RUFF INSTEAD
-
-[flake8]
-exclude = .ipynb_checkpoints, .venv, docs, build
-max-line-length = 88
-ignore = E731,E741,W503,E203,E501

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    - name: Set up Python 3.12
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
         python-version: '3.13'

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    - name: Set up Python
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
         python-version: '3.13'

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -38,12 +38,10 @@ jobs:
       run: |
         uv venv --python $(which python)
         uv sync --extra all --extra build --extra ops --extra test
-    - name: Check formatting with black
-      run: uv run black --check .
-    - name: Check imports with isort
-      run: uv run isort -c .
-    - name: Lint with flake8
-      run: uv run flake8 .
+    - name: Lint with ruff
+      run: uv run ruff check
+    - name: Check format with ruff
+      run: uv run ruff format
     - name: Test with pytest
       run: uv run pytest
     - name: Validate build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,7 @@
 repos:
-- repo: https://github.com/psf/black
-  rev: 25.1.0
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.12.4
   hooks:
-  - id: black
-    
-- repo: https://github.com/timothycrosley/isort
-  rev: 6.0.1
-  hooks:
-  - id: isort
-
-- repo: https://github.com/pycqa/flake8
-  rev: 7.3.0
-  hooks:
-  - id: flake8
+  - id: ruff-check
+    args: [--fix]
+  - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,12 +148,6 @@ exclude = [
     ".venv",
     "docs",
     "build",
-    "rubicon_ml/client/__init__.py"
-]
-extend-ignore = [
-    "E731",  # do not assign a lambda expression, use a def
-    "E741",  # ambiguous variable name
-    "W503",  # line break before binary operator
-    "E203",  # whitespace before ':'
-    "E501"   # line too long (handled by line-length)
+    "notebooks",
+    # "rubicon_ml/client/__init__.py"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,8 +146,8 @@ line-length = 100
 exclude = [
     ".ipynb_checkpoints",
     ".venv",
-    "docs",
+    "binder",
     "build",
+    "docs",
     "notebooks",
-    # "rubicon_ml/client/__init__.py"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,3 +140,20 @@ upgrade = [
     "scikit-learn"
 ]
 command = "pytest"
+
+[tool.ruff]
+line-length = 100
+exclude = [
+    ".ipynb_checkpoints",
+    ".venv",
+    "docs",
+    "build",
+    "rubicon_ml/client/__init__.py"
+]
+extend-ignore = [
+    "E731",  # do not assign a lambda expression, use a def
+    "E741",  # ambiguous variable name
+    "W503",  # line break before binary operator
+    "E203",  # whitespace before ':'
+    "E501"   # line too long (handled by line-length)
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.9.0"
 authors = [
     { name = "Ryan Soley" },
-    { name = "CapitalOne" }
+    { name = "Capital One" }
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -52,12 +52,10 @@ docs = [
     "sphinx-copybutton"
 ]
 ops = [
-    "black",
     "bumpver",
     "edgetest",
-    "flake8",
-    "isort",
-    "pre-commit"
+    "pre-commit",
+    "ruff"
 ]
 s3 = ["s3fs<=2025.7.0,>=0.4"]
 test = [
@@ -116,22 +114,6 @@ packages = ["rubicon_ml"]
 
 [tool.setuptools.package-data]
 rubicon_ml = ["py.typed"]
-
-[tool.black]
-line-length = 100
-
-[tool.isort]
-line_length = 88
-skip = [
-    ".venv",
-    "build",
-    "rubicon_ml/client/__init__.py",
-]
-filter_files = true
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-combine_as_imports = true
 
 [tool.pytest.ini_options]
 markers = [

--- a/rubicon_ml/client/mixin.py
+++ b/rubicon_ml/client/mixin.py
@@ -631,8 +631,7 @@ class DataframeMixin:
                 raise RubiconException(f"No dataframe found with name '{name}'.")
             elif len(dataframes) > 1:
                 warnings.warn(
-                    f"Multiple dataframes found with name '{name}'."
-                    " Returning most recently logged."
+                    f"Multiple dataframes found with name '{name}'. Returning most recently logged."
                 )
 
             dataframe = dataframes[-1]

--- a/rubicon_ml/viz/metric_lists_comparison.py
+++ b/rubicon_ml/viz/metric_lists_comparison.py
@@ -148,8 +148,7 @@ class MetricListsComparison(VizBase):
                         experiment_ids.append(experiment_id[:7])
 
             header_right_text = (
-                f"over {len(experiment_ids)} experiment"
-                f"{'s' if len(experiment_ids) != 1 else ''}"
+                f"over {len(experiment_ids)} experiment{'s' if len(experiment_ids) != 1 else ''}"
             )
 
             if len(heatmap_data) == 0:


### PR DESCRIPTION
## What
  * migrates off `black`, `isort` and `flake8` in favor of `ruff`
    * https://github.com/astral-sh/ruff

## How to Test
  * `uv run ruff check`
  * `uv run ruff format`
