### PR TITLE
fix: `edgetest` config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,11 +126,14 @@ upgrade = [
 command = "pytest"
 
 [tool.setuptools]
-packages = ["rubicon_ml"]
 package-dir = {"" = "."}
 
 [tool.setuptools.package-data]
 rubicon_ml = ["py.typed"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["rubicon_ml*"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ Documentation = "https://capitalone.github.io/rubicon-ml/"
 "Source Code" = "https://github.com/capitalone/rubicon-ml"
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [bumpver]
@@ -126,6 +126,7 @@ upgrade = [
 command = "pytest"
 
 [tool.setuptools]
+include-package-data = true
 package-dir = {"" = "."}
 
 [tool.setuptools.package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,23 +109,8 @@ version_pattern = "MAJOR.MINOR.PATCH"
 ]
 "rubicon_ml/__init__.py" = ['__version__ = "{version}"']
 
-[tool.setuptools]
-packages = ["rubicon_ml"]
-
-[tool.setuptools.package-data]
-rubicon_ml = ["py.typed"]
-
-[tool.pytest.ini_options]
-markers = [
-    "run_notebooks: tests that run Jupyter notebooks",
-    "write_files: tests that physically write files to local and S3 filesystems",
-]
-addopts = "--cov=./rubicon_ml --cov-report=term-missing --cov-fail-under=90 -m='not write_files'"
-minversion = "3.2"
-xfail_strict = true
-
-[tool.edgetest.envs.core]
-python_version = "3.12"
+[edgetest.envs.core]
+python_version = "3.13"
 extras = ["dev"]
 upgrade = [
     "click",
@@ -140,6 +125,21 @@ upgrade = [
     "scikit-learn"
 ]
 command = "pytest"
+
+[tool.setuptools]
+packages = ["rubicon_ml"]
+
+[tool.setuptools.package-data]
+rubicon_ml = ["py.typed"]
+
+[tool.pytest.ini_options]
+markers = [
+    "run_notebooks: tests that run Jupyter notebooks",
+    "write_files: tests that physically write files to local and S3 filesystems",
+]
+addopts = "--cov=./rubicon_ml --cov-report=term-missing --cov-fail-under=90 -m='not write_files'"
+minversion = "3.2"
+xfail_strict = true
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ command = "pytest"
 
 [tool.setuptools]
 packages = ["rubicon_ml"]
+package-dir = {"" = "."}
 
 [tool.setuptools.package-data]
 rubicon_ml = ["py.typed"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,6 @@ version_pattern = "MAJOR.MINOR.PATCH"
 "rubicon_ml/__init__.py" = ['__version__ = "{version}"']
 
 [edgetest.envs.core]
-python_version = "3.13"
 extras = ["dev"]
 upgrade = [
     "click",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,12 @@ include-package-data = true
 package-dir = {"" = "."}
 
 [tool.setuptools.package-data]
-rubicon_ml = ["py.typed"]
+rubicon_ml = [
+    "schema/schema/*.yaml",
+    "viz/assets/*",
+    "viz/assets/css/*",
+    "py.typed",
+]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/notebooks/test_notebooks.py
+++ b/tests/notebooks/test_notebooks.py
@@ -69,7 +69,7 @@ def test_notebooks_execute_without_error(notebook_filename):
     notebook = read_notebook_file(notebook_filename)
     resources = {"metadata": {"path": os.path.dirname(notebook_filename)}}
 
-    preprocessor = ExecutePreprocessor(kernel_name="python3", timeout=60)
+    preprocessor = ExecutePreprocessor(timeout=60)
     preprocessor.preprocess(notebook, resources=resources)
 
     repo_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))


### PR DESCRIPTION
## What
  * `edgetest` hasn't actually been working since switching to `uv` - just showing a green build despite failing
    * notebooks tests are failing to import the library
    * needed to properly included non-code assets
  * uses the proper name for the `edgetest` section in pyproject.toml
  * removes `python_version` - this is erroring locally despite seeming fine on the actions
  * explicitly include non-code assets

## How to Test
  * validate the `edgetest` action
    - [x] https://github.com/capitalone/rubicon-ml/actions/runs/16425778593/job/46415561030 
