### PR TITLE
fix: run `twine` with `uv` in publish action

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -47,7 +47,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         TWINE_REPOSITORY: pypi
       run: |
-        twine upload dist/*
+        uv run twine upload dist/*
     - name: Create GitHub tag & release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Title your release PR `release: vx.y.z` to trigger a release of version x.y.z
on merge. The uncommented content of this PR will be used as the body of the
release - make sure it is complete and accurate.

Fill out the <PREVIOUS_VERSION> and <RELEASE_VERSION> in the changelog link,
then uncomment relevent sections below and add a list of all commits in this
release to the appropriate sections with a link to thier PR, i.e.:

**full changelog**: https://github.com/capitalone/rubicon-ml/compare/0.0.1...0.0.2

## changes
  * feat: add S3 backend repository (#100)
-->

**full changelog**: https://github.com/capitalone/rubicon-ml/compare/0.11.0...0.12.0

## breaking changes
* ops(integration): modernization (#524)
  * **only a breaking change for developers** - check out the new [developer guide](https://capitalone.github.io/rubicon-ml/developer-guide.html) for details

## changes
* ops: add explicit write permissions to workflows (#527)
* ops: changes by run-edgetest action (#528)
* ops: changes by run-edgetest action (#530)
* ops: changes by run-edgetest action (#532)

<!--
## deprecations
* 
-->

<!--
## bugfixes
* 
-->
