### PR TITLE
ops (WIP): use bot in docs publishing action

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -45,3 +45,5 @@ jobs:
       with:
         branch: gh-pages
         folder: docs/build/html
+        git-config-name: github-actions[bot]
+        git-config-email: github-actions[bot]@users.noreply.github.com

--- a/docs/source/faqs.rst
+++ b/docs/source/faqs.rst
@@ -3,6 +3,8 @@
 FAQs
 ****
 
+**testing docs bot**
+
 Why the name?
 =============
 


### PR DESCRIPTION
## Changes
  * sets the gh-pages publisher to the actions bot rather than the default (user's personal account)
    * this should simplify branch protections for the gh-pages branch

## How to Test
  * manually run the docs build action
    * [succeeded](https://github.com/capitalone/rubicon-ml/actions/runs/16916648057/job/47932104111) with the bot username & email, but now we can't properly configure branch protections
