### PR TITLE
ops: update edgetest's python

### DIFF
--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -12,17 +12,18 @@ on:
 
 jobs:
   edgetest:
-    runs-on: ubuntu-latest
-    name: running edgetest
+    name: Run edgetest
     permissions:
       contents: write
       pull-requests: write
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
     - id: run-edgetest
       uses: edgetest-dev/run-edgetest-action@v1.6
       with:
-        edgetest-flags: '-c pyproject.toml --export'
         base-branch: 'main'
+        edgetest-flags: '-c pyproject.toml --export'
+        python-version: 3.12
         skip-pr: 'false'


### PR DESCRIPTION
## Changes
  * updates the edgetest action's python version to 3.12 to pick up latest versions of dependencies like numpy

## How to Test
  * run the edgetest action
    * 
