### PR TITLE
release: v0.13.2

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -4,6 +4,8 @@
 #   - https://github.com/actions/checkout
 #   - https://github.com/actions/setup-python
 #   - https://github.com/astral-sh/setup-uv
+#
+# TODO: fix for private mirrors
 
 name: Publish to PyPI
 


### PR DESCRIPTION
<!--
Title your release PR `release: vx.y.z` to trigger a release of version x.y.z
on merge. The uncommented content of this PR will be used as the body of the
release - make sure it is complete and accurate.

Fill out the <PREVIOUS_VERSION> and <RELEASE_VERSION> in the changelog link,
then uncomment relevent sections below and add a list of all commits in this
release to the appropriate sections with a link to thier PR, i.e.:

**full changelog**: https://github.com/capitalone/rubicon-ml/compare/0.0.1...0.0.2

## changes
  * feat: add S3 backend repository (#100)
-->

**full changelog**: https://github.com/capitalone/rubicon-ml/compare/0.13.1...0.13.2

<!--
## breaking changes
* 
-->

## changes
* reverts the move of the artifact logging from each individual schema to the base schema (#560)
* registers the new h2o__H2OGenericEstimator schema in registry.py (#560)

<!--
## deprecations
* 
-->

<!--
## bugfixes
* 
-->
