### PR TITLE
feat: deprecate intake

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,1 +1,0 @@
-rubicon-ml

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,1 +1,1 @@
-rubicon-ml[dev]
+rubicon-ml

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -82,11 +82,12 @@ exception_handling
 
 .. autofunction:: rubicon_ml.set_failure_mode
 
-publish
-=======
-``rubicon_ml`` leverages ``intake`` to easily share sets of experiments.
+publish (deprecated)
+====================
+``rubicon_ml.publish`` is deprecated and will be removed in an upcoming release.
+It requires the ``intake`` optional dependency: ``pip install rubicon-ml[intake]``.
 
-.. autofunction:: rubicon_ml.publish
+.. autofunction:: rubicon_ml.intake_rubicon.publish.publish
 
 .. _library-reference-sklearn:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,8 +21,6 @@ rubicon-ml's core functionality is broken down into three parts...
 
 * `Logging`_: organize, store, and retrieve model inputs and outputs with various
   backend storage options - powered by fsspec_
-* `Sharing`_: share a selected subset of logged data with collaborators or reviewers
-  - powered by intake_
 * `Visualizing`_: explore and compare logged model metadata with the dashboard and
   other widgets - powered by dash_
 
@@ -159,9 +157,7 @@ To install all extra modules, use the ``all`` extra.
 
 .. _fsspec: https://filesystem-spec.readthedocs.io/en/latest/?badge=latest
 .. _dash: https://dash.plotly.com/
-.. _intake: https://intake.readthedocs.io/en/latest/
 .. _quick look: ./quick-look/logging-experiments.html
 .. _Logging: ./quick-look/logging-experiments.html
-.. _Sharing: ./quick-look/sharing-experiments.html
 .. _Visualizing: ./quick-look/visualizing-experiments.html
 .. _Prefect integration: ./integrations/integration-prefect-workflows.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ classifiers = [
 dependencies = [
     "click<=8.3.1,>=7.1",
     "fsspec<=2026.3.0,>=2021.4.0",
-    "intake<=2.0.9,>=0.5.2",
     "numpy<=2.4.4,>=1.22.0",
     "pandas<=3.0.2,>=1.0.0",
     "pyarrow<=23.0.1,>=14.0.1",
@@ -44,7 +43,7 @@ dependencies = [
     "scikit-learn<=1.8.0,>=0.22.0",
 ]
 optional-dependencies.all = [
-    "rubicon-ml[jsonpath,s3,viz]",
+    "rubicon-ml[intake,jsonpath,s3,viz]",
 ]
 optional-dependencies.build = [
     "build",
@@ -53,7 +52,7 @@ optional-dependencies.build = [
     "wheel",
 ]
 optional-dependencies.dev = [
-    "rubicon-ml[build,docs,jsonpath,ops,s3,test,viz]",
+    "rubicon-ml[build,docs,intake,jsonpath,ops,s3,test,viz]",
 ]
 optional-dependencies.docs = [
     "furo",
@@ -61,9 +60,12 @@ optional-dependencies.docs = [
     "nbsphinx",
     "numpydoc",
     "pandoc",
-    "rubicon-ml[jsonpath,viz]",
+    "rubicon-ml[intake,jsonpath,viz]",
     "sphinx",
     "sphinx-copybutton",
+]
+optional-dependencies.intake = [
+    "intake<=2.0.9,>=0.5.2",
 ]
 optional-dependencies.jsonpath = [
     "jsonpath-ng<=1.8.0,>=1.5.3",
@@ -178,7 +180,6 @@ extras = [
 upgrade = [
     "click",
     "fsspec",
-    "intake",
     "jsonpath-ng",
     "numpy",
     "pandas",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,15 +3,9 @@
 click==8.3.1
     # via rubicon-ml (pyproject.toml)
 fsspec==2026.3.0
-    # via
-    #   rubicon-ml (pyproject.toml)
-    #   intake
-intake==2.0.9
     # via rubicon-ml (pyproject.toml)
 joblib==1.5.3
     # via scikit-learn
-networkx==3.6.1
-    # via intake
 numpy==2.4.4
     # via
     #   rubicon-ml (pyproject.toml)
@@ -20,16 +14,12 @@ numpy==2.4.4
     #   scipy
 pandas==3.0.2
     # via rubicon-ml (pyproject.toml)
-platformdirs==4.9.4
-    # via intake
 pyarrow==23.0.1
     # via rubicon-ml (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via pandas
 pyyaml==6.0.3
-    # via
-    #   rubicon-ml (pyproject.toml)
-    #   intake
+    # via rubicon-ml (pyproject.toml)
 scikit-learn==1.8.0
     # via rubicon-ml (pyproject.toml)
 scipy==1.17.1

--- a/rubicon_ml/__init__.py
+++ b/rubicon_ml/__init__.py
@@ -1,5 +1,7 @@
 __version__ = "0.14.1"
 
+import importlib
+
 from rubicon_ml.client import (  # noqa: E402
     Artifact,
     Dataframe,
@@ -12,7 +14,6 @@ from rubicon_ml.client import (  # noqa: E402
     RubiconJSON,
 )
 from rubicon_ml.client.utils.exception_handling import set_failure_mode  # noqa: E402
-from rubicon_ml.intake_rubicon.publish import publish  # noqa: E402
 
 __all__ = [
     "Artifact",
@@ -22,8 +23,12 @@ __all__ = [
     "Metric",
     "Parameter",
     "Project",
-    "publish",
     "Rubicon",
     "RubiconJSON",
     "set_failure_mode",
 ]
+
+if importlib.util.find_spec("intake"):
+    from rubicon_ml.intake_rubicon.publish import publish  # noqa: E402, F401
+
+    __all__.append("publish")

--- a/rubicon_ml/intake_rubicon/__init__.py
+++ b/rubicon_ml/intake_rubicon/__init__.py
@@ -1,17 +1,42 @@
-import intake  # noqa F401
+import importlib
+import logging
+import warnings
 
-from rubicon_ml.intake_rubicon.experiment import ExperimentSource
-from rubicon_ml.intake_rubicon.viz import (
-    DataframePlotDataSource,
-    ExperimentsTableDataSource,
-    MetricCorrelationPlotDataSource,
-    MetricListComparisonDataSource,
+LOGGER = logging.getLogger(__name__)
+
+_DEPRECATION_MSG = "`intake_rubicon` is deprecated and will be removed in an upcoming release."
+_INSTALL_MSG = (
+    "`intake` is required to use `intake_rubicon`. Please install it with "
+    "`pip install intake` or `pip install rubicon-ml[intake]`."
 )
 
-__all__ = [
-    "ExperimentSource",
-    "ExperimentsTableDataSource",
-    "MetricCorrelationPlotDataSource",
-    "DataframePlotDataSource",
-    "MetricListComparisonDataSource",
-]
+
+def _check_intake():
+    """Check that intake is installed and emit a deprecation warning."""
+    warnings.warn(_DEPRECATION_MSG, category=DeprecationWarning, stacklevel=3)
+    LOGGER.warning(_DEPRECATION_MSG)
+
+    if not importlib.util.find_spec("intake"):
+        raise ImportError(_INSTALL_MSG)
+
+
+if importlib.util.find_spec("intake"):
+    import intake  # noqa F401
+
+    from rubicon_ml.intake_rubicon.experiment import ExperimentSource
+    from rubicon_ml.intake_rubicon.viz import (
+        DataframePlotDataSource,
+        ExperimentsTableDataSource,
+        MetricCorrelationPlotDataSource,
+        MetricListComparisonDataSource,
+    )
+
+    __all__ = [
+        "ExperimentSource",
+        "ExperimentsTableDataSource",
+        "MetricCorrelationPlotDataSource",
+        "DataframePlotDataSource",
+        "MetricListComparisonDataSource",
+    ]
+else:
+    __all__ = []

--- a/rubicon_ml/intake_rubicon/base.py
+++ b/rubicon_ml/intake_rubicon/base.py
@@ -1,6 +1,7 @@
 from intake.source import base
 
 from rubicon_ml import __version__
+from rubicon_ml.intake_rubicon import _check_intake
 
 
 class DataSourceMixin(base.DataSource):
@@ -20,6 +21,8 @@ class DataSourceMixin(base.DataSource):
     name = "rubicon_ml"
 
     def __init__(self, urlpath, project_name, metadata=None, storage_options=None, **kwargs):
+        _check_intake()
+
         self._urlpath = urlpath
         self._project_name = project_name
         self._metadata = metadata or {}
@@ -60,6 +63,8 @@ class VizDataSourceMixin(base.DataSource):
         self,
         metadata=None,
     ):
+        _check_intake()
+
         self._metadata = metadata or {}
         self._visualization_object = None
 

--- a/rubicon_ml/intake_rubicon/publish.py
+++ b/rubicon_ml/intake_rubicon/publish.py
@@ -3,6 +3,8 @@ from typing import TYPE_CHECKING, Optional, Union
 import fsspec
 import yaml
 
+from rubicon_ml.intake_rubicon import _check_intake
+
 if TYPE_CHECKING:
     from rubicon_ml.viz import DataframePlot
     from rubicon_ml.viz.experiments_table import ExperimentsTable
@@ -41,6 +43,7 @@ def publish(
         The YAML string representation of the `intake` catalog
         containing the experiments `experiments`.
     """
+    _check_intake()
 
     if base_catalog_filepath is not None:
         return _update_catalog(

--- a/rubicon_ml/viz/experiments_table.py
+++ b/rubicon_ml/viz/experiments_table.py
@@ -1,12 +1,15 @@
+import importlib
+import logging
 import os
 
 import dash_bootstrap_components as dbc
 from dash import dash_table, dcc, html
 from dash.dependencies import ALL, Input, Output, State
 
-from rubicon_ml.intake_rubicon.publish import publish
 from rubicon_ml.viz.base import VizBase
 from rubicon_ml.viz.common.colors import light_blue, plot_background_blue
+
+LOGGER = logging.getLogger(__name__)
 
 
 class ExperimentsTable(VizBase):
@@ -446,6 +449,15 @@ class ExperimentsTable(VizBase):
                 selected_experiments = [
                     e for e in self.experiments if e.id in selected_experiment_ids
                 ]
+
+                if not importlib.util.find_spec("intake"):
+                    LOGGER.warning(
+                        "`intake` is required to publish experiments. Install it with "
+                        "`pip install rubicon-ml[intake]`."
+                    )
+                    return False
+
+                from rubicon_ml.intake_rubicon.publish import publish
 
                 publish(selected_experiments, publish_path)
 


### PR DESCRIPTION
## Changes
  * remove `intake` from core dependencies
    * the latest versions of `intake` are vulnerable, causing whitesource to block PRs, and there doesn't appear to be much momentum on the library to fix it
  *  deprecate core functionality that uses `intake` (`publish`)
  * removes 'binder/requirements.txt'
    * it pulls in literal rubicon, so since it exists with the intake vulnerability there's no solving without a new release
      * we can put it back after we cut a new release or just totally deprecate binder - idt it works even with this file 

## How to Test
  * `python -m pytest`
