### PR TITLE
fix: `wandb` entity

### DIFF
--- a/rubicon_ml/repository/wandb.py
+++ b/rubicon_ml/repository/wandb.py
@@ -129,6 +129,9 @@ class WandBRepository(BaseRepository):
             }
             run_config.update(self.wandb_init_kwargs)
 
+            if self.entity:
+                run_config["entity"] = self.entity
+
             self._active_run = self.wandb.init(**run_config)
 
         return self._active_run
@@ -346,6 +349,8 @@ class WandBRepository(BaseRepository):
             }
             run_config.update(self.wandb_init_kwargs)
 
+            if self.entity:
+                run_config["entity"] = self.entity
             if entity.name:
                 run_config["name"] = entity.name
             if entity.tags:

--- a/tests/unit/repository/test_wandb_repo.py
+++ b/tests/unit/repository/test_wandb_repo.py
@@ -1,0 +1,101 @@
+from unittest.mock import MagicMock, patch
+
+from rubicon_ml import domain
+from rubicon_ml.repository import WandBRepository
+
+
+def _make_repo(**kwargs):
+    return WandBRepository(warn=False, **kwargs)
+
+
+@patch("rubicon_ml.repository.wandb.WandBRepository.wandb", new_callable=lambda: property(lambda self: MagicMock()))
+def test_get_active_run_passes_entity(mock_wandb_prop):
+    mock_wandb = MagicMock()
+    mock_run = MagicMock()
+    mock_wandb.init.return_value = mock_run
+
+    repo = _make_repo(entity="my-team")
+
+    with patch.object(type(repo), "wandb", new_callable=lambda: property(lambda self: mock_wandb)):
+        repo._get_active_run("test-project", "run-123")
+
+    mock_wandb.init.assert_called_once()
+    call_kwargs = mock_wandb.init.call_args[1]
+    assert call_kwargs["entity"] == "my-team"
+    assert call_kwargs["project"] == "test-project"
+    assert call_kwargs["id"] == "run-123"
+    assert call_kwargs["resume"] == "must"
+
+
+@patch("rubicon_ml.repository.wandb.WandBRepository.wandb", new_callable=lambda: property(lambda self: MagicMock()))
+def test_get_active_run_omits_entity_when_none(mock_wandb_prop):
+    mock_wandb = MagicMock()
+    mock_run = MagicMock()
+    mock_wandb.init.return_value = mock_run
+
+    repo = _make_repo()
+
+    with patch.object(type(repo), "wandb", new_callable=lambda: property(lambda self: mock_wandb)):
+        repo._get_active_run("test-project", "run-123")
+
+    mock_wandb.init.assert_called_once()
+    call_kwargs = mock_wandb.init.call_args[1]
+    assert "entity" not in call_kwargs
+
+
+@patch("rubicon_ml.repository.wandb.WandBRepository.wandb", new_callable=lambda: property(lambda self: MagicMock()))
+def test_persist_experiment_passes_entity(mock_wandb_prop):
+    mock_wandb = MagicMock()
+    mock_run = MagicMock()
+    mock_run.id = "run-456"
+    mock_run.name = "test-run"
+    mock_wandb.init.return_value = mock_run
+
+    repo = _make_repo(entity="my-team")
+    repo._current_project = domain.Project(name="test-project")
+
+    experiment = domain.Experiment(name="test-experiment", project_name="test-project")
+
+    with patch.object(type(repo), "wandb", new_callable=lambda: property(lambda self: mock_wandb)):
+        repo._persist_domain(experiment, "unused-path")
+
+    mock_wandb.init.assert_called_once()
+    call_kwargs = mock_wandb.init.call_args[1]
+    assert call_kwargs["entity"] == "my-team"
+    assert call_kwargs["project"] == "test-project"
+
+
+@patch("rubicon_ml.repository.wandb.WandBRepository.wandb", new_callable=lambda: property(lambda self: MagicMock()))
+def test_persist_experiment_omits_entity_when_none(mock_wandb_prop):
+    mock_wandb = MagicMock()
+    mock_run = MagicMock()
+    mock_run.id = "run-456"
+    mock_run.name = "test-run"
+    mock_wandb.init.return_value = mock_run
+
+    repo = _make_repo()
+    repo._current_project = domain.Project(name="test-project")
+
+    experiment = domain.Experiment(name="test-experiment", project_name="test-project")
+
+    with patch.object(type(repo), "wandb", new_callable=lambda: property(lambda self: mock_wandb)):
+        repo._persist_domain(experiment, "unused-path")
+
+    mock_wandb.init.assert_called_once()
+    call_kwargs = mock_wandb.init.call_args[1]
+    assert "entity" not in call_kwargs
+
+
+@patch("rubicon_ml.repository.wandb.WandBRepository.wandb", new_callable=lambda: property(lambda self: MagicMock()))
+def test_wandb_init_kwargs_can_override_entity(mock_wandb_prop):
+    mock_wandb = MagicMock()
+    mock_run = MagicMock()
+    mock_wandb.init.return_value = mock_run
+
+    repo = _make_repo(entity="my-team", wandb_init_kwargs={"entity": "override-team"})
+
+    with patch.object(type(repo), "wandb", new_callable=lambda: property(lambda self: mock_wandb)):
+        repo._get_active_run("test-project", "run-123")
+
+    call_kwargs = mock_wandb.init.call_args[1]
+    assert call_kwargs["entity"] == "override-team"

--- a/tests/unit/repository/test_wandb_repo.py
+++ b/tests/unit/repository/test_wandb_repo.py
@@ -84,18 +84,3 @@ def test_persist_experiment_omits_entity_when_none(mock_wandb_prop):
     mock_wandb.init.assert_called_once()
     call_kwargs = mock_wandb.init.call_args[1]
     assert "entity" not in call_kwargs
-
-
-@patch("rubicon_ml.repository.wandb.WandBRepository.wandb", new_callable=lambda: property(lambda self: MagicMock()))
-def test_wandb_init_kwargs_can_override_entity(mock_wandb_prop):
-    mock_wandb = MagicMock()
-    mock_run = MagicMock()
-    mock_wandb.init.return_value = mock_run
-
-    repo = _make_repo(entity="my-team", wandb_init_kwargs={"entity": "override-team"})
-
-    with patch.object(type(repo), "wandb", new_callable=lambda: property(lambda self: mock_wandb)):
-        repo._get_active_run("test-project", "run-123")
-
-    call_kwargs = mock_wandb.init.call_args[1]
-    assert call_kwargs["entity"] == "override-team"


### PR DESCRIPTION
## Changes
  * actually references the input `entity` when creating run configurations for `wandb` team logging

## How to Test
  * run the wandb regression test
