### PR TITLE
fix: composite config in project client

### DIFF
--- a/rubicon_ml/client/rubicon.py
+++ b/rubicon_ml/client/rubicon.py
@@ -202,7 +202,7 @@ class Rubicon:
                 except Exception as err:
                     return_err = err
                 else:
-                    return Project(project, self.config)
+                    return Project(project, self.configs)
 
             if len(self.repositories) > 1:
                 raise RubiconException("all configured storage backends failed") from return_err
@@ -287,7 +287,7 @@ class Rubicon:
 
         for repo in self.repositories:
             try:
-                projects = [Project(project, self.config) for project in repo.get_projects()]
+                projects = [Project(project, self.configs) for project in repo.get_projects()]
             except Exception as err:
                 return_err = err
             else:

--- a/tests/unit/client/test_rubicon_client.py
+++ b/tests/unit/client/test_rubicon_client.py
@@ -298,3 +298,36 @@ def test_get_project_as_pandas_df(rubicon_and_project_client_with_experiments):
     ddf = rubicon.get_project_as_df(name="Test Project", df_type="pandas")
 
     assert isinstance(ddf, pd.DataFrame)
+
+
+def test_get_project_composite_returns_all_configs(rubicon_composite_client):
+    rubicon = rubicon_composite_client
+    rubicon.create_project("Test Project")
+
+    project = rubicon.get_project("Test Project")
+
+    assert project._config == rubicon.configs
+
+
+def test_projects_composite_returns_all_configs(rubicon_composite_client):
+    rubicon = rubicon_composite_client
+    rubicon.create_project("Test Project")
+
+    projects = rubicon.projects()
+
+    assert all(p._config == rubicon.configs for p in projects)
+
+
+def test_get_or_create_project_composite_writes_all_backends(rubicon_composite_client):
+    rubicon = rubicon_composite_client
+    rubicon.repositories[0].create_project(domain.Project("Test Project"))
+
+    project = rubicon.get_or_create_project("Test Project")
+    experiment = project.log_experiment()
+
+    repo_a, repo_b = rubicon.repositories
+    experiments_a = repo_a.get_experiments("Test Project")
+    experiments_b = repo_b.get_experiments("Test Project")
+
+    assert any(e.id == experiment.id for e in experiments_a)
+    assert any(e.id == experiment.id for e in experiments_b)


### PR DESCRIPTION
## Changes

fixes a composite config bug where `get_or_create_project` silently dropped secondary backends when only some, but not all backends had an existing project with the requested name

## How to Test

  * `python -m pytest tests/unit/client/test_rubicon_client.py`
  * validate the following MRE now succeeds:
```python
import uuid                            
from rubicon_ml import Rubicon

composite_config = [
    {"persistence": "filesystem", "root_dir": "./rubicon-data-a"},
    {"persistence": "filesystem", "root_dir": "./rubicon-data-b"},
]
project_name = str(uuid.uuid4())

# simulate project pre-existing in backend A only (prior run, non-composite client, etc.)
rubicon_a = Rubicon(**composite_config[0])
rubicon_a.create_project(project_name)

# composite client finds it in A, takes get path, returns single-config project
rubicon = Rubicon(composite_config=composite_config)
project = rubicon.get_or_create_project(project_name)
experiment = project.log_experiment()

rubicon_b = Rubicon(**composite_config[1])
rubicon_b.get_project(project_name)  # originally fails as project never created in B
```