### PR TITLE
ops: use SHAs in actions & native GH docs actions

### DIFF
--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -27,7 +27,7 @@ jobs:
         python-version: 3.12
     - id: run-edgetest
       name: Run edgetest
-      uses: edgetest-dev/run-edgetest-action@8ceeac94abe951d6b51305454bc6d0ff2096e2ec# v1.7.0
+      uses: edgetest-dev/run-edgetest-action@8ceeac94abe951d6b51305454bc6d0ff2096e2ec  # v1.7.0
       with:
         base-branch: 'main'
         edgetest-flags: '-c pyproject.toml --export'

--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -19,14 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
         python-version: 3.12
     - id: run-edgetest
       name: Run edgetest
-      uses: edgetest-dev/run-edgetest-action@v1.6
+      uses: edgetest-dev/run-edgetest-action@fb6dcd4e5f6ee4c87769c9701c472f58b7e9ab6c  # v1.6.0
       with:
         base-branch: 'main'
         edgetest-flags: '-c pyproject.toml --export'

--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -2,6 +2,7 @@
 #
 # Public actions used:
 #   - https://github.com/actions/checkout
+#   - https://github.com/actions/setup-python
 #   - https://github.com/edgetest-dev/run-edgetest-action
 
 name: Run edgetest
@@ -21,7 +22,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
       with:
         python-version: 3.12
     - id: run-edgetest

--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -27,7 +27,7 @@ jobs:
         python-version: 3.12
     - id: run-edgetest
       name: Run edgetest
-      uses: edgetest-dev/run-edgetest-action@fb6dcd4e5f6ee4c87769c9701c472f58b7e9ab6c  # v1.6.0
+      uses: edgetest-dev/run-edgetest-action@8ceeac94abe951d6b51305454bc6d0ff2096e2ec# v1.7.0
       with:
         base-branch: 'main'
         edgetest-flags: '-c pyproject.toml --export'

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   build:
-    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
+    if: (github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
@@ -52,7 +52,7 @@ jobs:
       with:
         path: docs/build/html/
   deploy:
-    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
+    if: (github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,30 +4,36 @@
 #   - https://github.com/actions/checkout
 #   - https://github.com/actions/setup-python
 #   - https://github.com/astral-sh/setup-uv
-#   - https://github.com/marketplace/actions/github-pages-deploy-action
+#   - https://github.com/actions/upload-pages-artifact
+#   - https://github.com/actions/deploy-pages
 
 name: Publish docs
 
 on:
-  release:
-    types: [created]
+  pull_request:
+    types: [closed]
+    branches:
+      - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+  id-token: write
+  pages: write
+
 jobs:
-  build-and-deploy:
+  build:
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pages: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
     - name: Set up Python 3.13
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
       with:
         python-version: '3.13'
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
       with:
         version: 'latest'
     - name: Install dependencies
@@ -40,8 +46,19 @@ jobs:
       run: |
         cd docs
         uv run make html
-    - name: Publish docs
-      uses: JamesIves/github-pages-deploy-action@v4
+    - name: Upload docs artifact
+      id: upload_pages
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
       with:
-        branch: gh-pages
-        folder: docs/build/html
+        path: docs/build/html/
+  deploy:
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.upload_pages.outputs.page_url }}
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: upload_pages
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -55,7 +55,7 @@ jobs:
     if: (github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment:
-      name: github-pages
+      name: ${{ github.ref_name == 'main' && 'github-pages' || 'github-pages-dev' }}
       url: ${{ steps.upload_pages.outputs.page_url }}
     needs: build
     steps:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -23,13 +23,13 @@ jobs:
       contents: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
     - name: Set up Python 3.13
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
       with:
         python-version: '3.13'
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
       with:
         version: 'latest'
     - name: Install dependencies

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -19,13 +19,13 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
       with:
         version: 'latest'
     - name: Install dependencies

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
     - name: Validate PR title
-      uses: amannn/action-semantic-pull-request@v5
+      uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50  # v6.1.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
closes: #554 

---

## Changes
  * updates actions to comply with enterprise security standards
    * uses SHAs instead of version tags
    * uses native GitHub actions for docs
      * uses deployments natively instead of gh-pages branch

## How to Test
  * actions can not be run from forks
    * https://github.com/capitalone/rubicon-ml/compare/main...ops(tmp)/action-shas was used to validate edgetest and publish-docs
      * validate it matches this branch (one line discrepancy is from missing edgetest.yml comment) 
  * validate each (possible) action
    - [x] edgetest
      - https://github.com/capitalone/rubicon-ml/actions/runs/28451668897/job/84315315975
      - ~https://github.com/capitalone/rubicon-ml/actions/runs/28205583824/job/83555429223~
        - requires update to https://github.com/edgetest-dev/run-edgetest-action
          - https://github.com/edgetest-dev/run-edgetest-action/pull/25
    - [x] publish-docs (dev)
      - https://github.com/capitalone/rubicon-ml/actions/runs/28206982457
    - [ ] ~publish-package~ no manual trigger, currently requires live test from release branch
    - [x] test-package
      - https://github.com/capitalone/rubicon-ml/actions/runs/28199833757/job/83536194309?pr=607
    - [x] validate-pr-title
      - https://github.com/capitalone/rubicon-ml/actions/runs/28199833762/job/83536194414?pr=607

## Post-Merge
  - [ ] delete gh-pages branch
  - [ ] validate publish-docs from main
  - [ ] validate publish-package
