### PR TITLE
Fix for publish() method positional misalignment.

### DIFF
--- a/rubicon_ml/viz/experiments_table.py
+++ b/rubicon_ml/viz/experiments_table.py
@@ -459,7 +459,7 @@ class ExperimentsTable(VizBase):
 
                 from rubicon_ml.intake_rubicon.publish import publish
 
-                publish(selected_experiments, publish_path)
+                publish(experiments=selected_experiments, output_filepath=publish_path)
 
                 return False
 


### PR DESCRIPTION
…publish() method to address positional misalignment.



---

closes: #616

Add the keyword arguments 'experiments' and 'output_filepath' to the publish() method to address positional misalignment.
---

## Changes
  experiments_table.py 
  line 462
  ```
 publish(experiments=selected_experiments, output_filepath=publish_path)
```

## How to Test
 
* Run the classification.ipynb notebook. 
* In the Experiments Table widget, select "PUBLISH SELECTED" and then "PUBLISH".
* This will downlod the  rubicon-ml-catalog.yml file .
* The next code cell will be successful
 ```
  import intake
  catalog = intake.open_catalog("./rubicon-ml-catalob.yml")
```
